### PR TITLE
Add notice to run VS with admin rights

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,6 @@ When the development environment is set you can simply follow this guidelines to
 3. Commit your changes: `git commit -am 'Add some feature'`
 4. Push to the branch: `git push origin my-new-feature`
 5. Submit a pull request :)
+
+#### Troubleshooting
+* Make sure you run Visual Studio as administrator, if not, then you get a bunch of errors when you try to compile NMM.


### PR DESCRIPTION
Because trying to compile solution without administrator rights will throw a bunch of errors in your face.
