### PR TITLE
Fix crash when copying file from game mods folder

### DIFF
--- a/NexusClient/ModAuthoring/ModBuilder.cs
+++ b/NexusClient/ModAuthoring/ModBuilder.cs
@@ -280,9 +280,9 @@ namespace Nexus.Client.ModAuthoring
 						strDest = ConfirmOverwrite(p_dlgConfirmOverwrite, strDest);
 						if (!String.IsNullOrEmpty(strDest))
 						{
-                            // Make sure we aren't copying mod to itself.
-                            if (!string.Equals(strMod, strDest, StringComparison.OrdinalIgnoreCase))
-							    File.Copy(strMod, strDest, true);
+							// Make sure we aren't copying mod to itself.
+							if (!string.Equals(strMod, strDest, StringComparison.OrdinalIgnoreCase))
+								File.Copy(strMod, strDest, true);
 							lstFoundMods.Add(strDest);
 						}
 						StepItemProgress();

--- a/NexusClient/ModAuthoring/ModBuilder.cs
+++ b/NexusClient/ModAuthoring/ModBuilder.cs
@@ -280,7 +280,9 @@ namespace Nexus.Client.ModAuthoring
 						strDest = ConfirmOverwrite(p_dlgConfirmOverwrite, strDest);
 						if (!String.IsNullOrEmpty(strDest))
 						{
-							File.Copy(strMod, strDest, true);
+                            // Make sure we aren't copying mod to itself.
+                            if (!string.Equals(strMod, strDest, StringComparison.OrdinalIgnoreCase))
+							    File.Copy(strMod, strDest, true);
 							lstFoundMods.Add(strDest);
 						}
 						StepItemProgress();


### PR DESCRIPTION
Fixes crash when you are trying to add mod, which is located in current game /Mods folder, to NMM.
