### PR TITLE
Fix path for FO4 BodySlide

### DIFF
--- a/Fallout4/Fallout4SupportedTools.cs
+++ b/Fallout4/Fallout4SupportedTools.cs
@@ -204,7 +204,7 @@ namespace Nexus.Client.Games.Fallout4
 
 			if (String.IsNullOrEmpty(strBS))
 			{
-				string strBSPath = Path.Combine(GameMode.GameModeEnvironmentInfo.InstallationPath, @"Data\CalienteTools\BodySlide");
+				string strBSPath = Path.Combine(GameMode.GameModeEnvironmentInfo.InstallationPath, @"Data\Tools\BodySlide");
 				if (Directory.Exists(strBSPath))
 				{
 					strBS = strBSPath;
@@ -319,7 +319,7 @@ namespace Nexus.Client.Games.Fallout4
 
 		private void ConfigBS()
 		{
-			string p_strToolName = "BS";
+			string p_strToolName = "BS2";
 			string p_strExecutableName = "BodySlide.exe";
 			string p_strToolID = "BS2";
 			Trace.TraceInformation(string.Format("Configuring {0}", p_strToolName));

--- a/Fallout4/Settings/SupportedToolsSettingsGroup.cs
+++ b/Fallout4/Settings/SupportedToolsSettingsGroup.cs
@@ -524,7 +524,7 @@ namespace Nexus.Client.Games.Fallout4
 
 				if (booReset)
 				{
-					string strBS = Path.Combine(GameModeDescriptor.InstallationPath, @"Data\CalienteTools\BodySlide");
+					string strBS = Path.Combine(GameModeDescriptor.InstallationPath, @"Data\Tools\BodySlide");
 					if (Directory.Exists(strBS))
 						strBSPath = strBS;
 					else

--- a/Skyrim/Settings/SupportedToolsSettingsGroup.cs
+++ b/Skyrim/Settings/SupportedToolsSettingsGroup.cs
@@ -21,7 +21,7 @@ namespace Nexus.Client.Games.Skyrim
 		private string m_strWryeBashDirectory = null;
 		private string m_strFNISDirectory = null;
 		private string m_strTES5EditDirectory = null;
-		private string m_strBS2Directory = null;
+		private string m_strBSDirectory = null;
 		private string m_strDSRPDirectory = null;
 		private string m_strPMDirectory = null;
 
@@ -122,18 +122,18 @@ namespace Nexus.Client.Games.Skyrim
 		}
 
 		/// <summary>
-		/// Gets or sets the path of the directory where BodySlide2 is installed.
+		/// Gets or sets the path of the directory where BodySlide is installed.
 		/// </summary>
-		/// <value>The path of the directory where BodySlide2 is installed.</value>
-		public string BS2Directory
+		/// <value>The path of the directory where BodySlide is installed.</value>
+		public string BSDirectory
 		{
 			get
 			{
-				return m_strBS2Directory;
+				return m_strBSDirectory;
 			}
 			set
 			{
-				SetPropertyIfChanged(ref m_strBS2Directory, value, () => BS2Directory);
+				SetPropertyIfChanged(ref m_strBSDirectory, value, () => BSDirectory);
 			}
 		}
 
@@ -211,7 +211,7 @@ namespace Nexus.Client.Games.Skyrim
 		/// </summary>
 		/// <returns><c>true</c> if the specified directory are not equals;
 		/// <c>false</c> otherwise.</returns>
-		protected bool ValidateDirectory(string p_strBOSSPath, string p_strBOSSPathName, string p_strBOSSProperty, string p_strWryeBashPath, string p_strWryeBashPathName, string p_strWryeBashProperty, string p_strFNISPath, string p_strFNISPathName, string p_strFNISProperty, string p_strBS2Path, string p_strBS2PathName, string p_strBS2Property, string p_strLOOTPath, string p_strLOOTPathName, string p_strLOOTProperty, string p_strTES5EditPath, string p_strTES5EditPathName, string p_strTES5EditProperty, string p_strDSRPPath, string p_strDSRPPathName, string p_strDSRPProperty, string p_strPMPath, string p_strPMPathName, string p_strPMProperty)
+		protected bool ValidateDirectory(string p_strBOSSPath, string p_strBOSSPathName, string p_strBOSSProperty, string p_strWryeBashPath, string p_strWryeBashPathName, string p_strWryeBashProperty, string p_strFNISPath, string p_strFNISPathName, string p_strFNISProperty, string p_strBSPath, string p_strBSPathName, string p_strBSProperty, string p_strLOOTPath, string p_strLOOTPathName, string p_strLOOTProperty, string p_strTES5EditPath, string p_strTES5EditPathName, string p_strTES5EditProperty, string p_strDSRPPath, string p_strDSRPPathName, string p_strDSRPProperty, string p_strPMPath, string p_strPMPathName, string p_strPMProperty)
 		{
 			Errors.Clear(p_strBOSSProperty);
 			if (String.IsNullOrEmpty(p_strBOSSPath))
@@ -231,10 +231,10 @@ namespace Nexus.Client.Games.Skyrim
 				Errors.SetError(p_strFNISProperty, String.Format("You must select a {0}.", p_strFNISPathName));
 				return false;
 			}
-			Errors.Clear(p_strBS2Property);
-			if (String.IsNullOrEmpty(p_strBS2Path))
+			Errors.Clear(p_strBSProperty);
+			if (String.IsNullOrEmpty(p_strBSPath))
 			{
-				Errors.SetError(p_strBS2Property, String.Format("You must select a {0}.", p_strBS2PathName));
+				Errors.SetError(p_strBSProperty, String.Format("You must select a {0}.", p_strBSPathName));
 				return false;
 			}
 			Errors.Clear(p_strDSRPProperty);
@@ -350,13 +350,13 @@ namespace Nexus.Client.Games.Skyrim
 		}
 
 		/// <summary>
-		/// Validates the selected BodySlide2 directory.
+		/// Validates the selected BodySlide directory.
 		/// </summary>
-		/// <returns><c>true</c> if the selected BodySlide2 directory is valid;
+		/// <returns><c>true</c> if the selected BodySlide directory is valid;
 		/// <c>false</c> otherwise.</returns>
-		protected bool ValidateBS2Directory()
+		protected bool ValidateBSDirectory()
 		{
-			return ValidateDirectory(BS2Directory, "BodySlide2 Directory", ObjectHelper.GetPropertyName(() => BS2Directory));
+			return ValidateDirectory(BSDirectory, "BodySlide Directory", ObjectHelper.GetPropertyName(() => BSDirectory));
 		}
 
 		/// <summary>
@@ -396,7 +396,7 @@ namespace Nexus.Client.Games.Skyrim
 		/// <c>false</c> otherwise.</returns>
 		public bool ValidateSettings()
 		{
-			return ValidateBOSSDirectory() && ValidateLOOTDirectory() && ValidateWryeBashDirectory() && ValidateFNISDirectory() && ValidateTES5EditDirectory() && ValidatePMDirectory() && ValidateDSRPDirectory() && ValidateBS2Directory();
+			return ValidateBOSSDirectory() && ValidateLOOTDirectory() && ValidateWryeBashDirectory() && ValidateFNISDirectory() && ValidateTES5EditDirectory() && ValidatePMDirectory() && ValidateDSRPDirectory() && ValidateBSDirectory();
 		}
 
 		#endregion
@@ -412,7 +412,7 @@ namespace Nexus.Client.Games.Skyrim
 			string strLOOTReg = String.Empty;
 			string strWryePath = String.Empty;
 			string strFNISPath = String.Empty;
-			string strBS2Path = String.Empty;
+			string strBSPath = String.Empty;
 			string strDSRPPath = String.Empty;
 			string strPMPath = String.Empty;
 			string strTES5EditPath = String.Empty;
@@ -508,15 +508,15 @@ namespace Nexus.Client.Games.Skyrim
 
 			if (EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId].ContainsKey("BS2"))
 			{
-				strBS2Path = EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId]["BS2"];
+				strBSPath = EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId]["BS2"];
 
-				if (String.IsNullOrEmpty(strBS2Path))
+				if (String.IsNullOrEmpty(strBSPath))
 				{
 					booReset = true;
 				}
-				else if (Directory.Exists(strBS2Path) || File.Exists(strBS2Path))
+				else if (Directory.Exists(strBSPath) || File.Exists(strBSPath))
 				{
-					FileAttributes attr = File.GetAttributes(strBS2Path);
+					FileAttributes attr = File.GetAttributes(strBSPath);
 					booReset = !attr.HasFlag(FileAttributes.Directory);
 				}
 				else
@@ -524,17 +524,17 @@ namespace Nexus.Client.Games.Skyrim
 
 				if (booReset)
 				{
-					string strBS2 = Path.Combine(GameModeDescriptor.InstallationPath, @"Data\CalienteTools\BodySlide");
-					if (Directory.Exists(strBS2))
-						strBS2Path = strBS2;
+					string strBS = Path.Combine(GameModeDescriptor.InstallationPath, @"Data\CalienteTools\BodySlide");
+					if (Directory.Exists(strBS))
+						strBSPath = strBS;
 					else
-						strBS2Path = String.Empty;
+						strBSPath = String.Empty;
 
 					booReset = false;
 				}
 
-				if (!String.IsNullOrEmpty(strBS2Path) && Directory.Exists(strBS2Path))
-					BS2Directory = strBS2Path;
+				if (!String.IsNullOrEmpty(strBSPath) && Directory.Exists(strBSPath))
+					BSDirectory = strBSPath;
 			}
 
 			if (EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId].ContainsKey("DSRP"))
@@ -631,8 +631,8 @@ namespace Nexus.Client.Games.Skyrim
 			if (!EnvironmentInfo.Settings.SupportedTools.ContainsKey(GameModeDescriptor.ModeId) || !EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId].ContainsKey("FNIS") || !String.Equals(EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId], FNISDirectory))
 				EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId]["FNIS"] = FNISDirectory;
 
-			if (!EnvironmentInfo.Settings.SupportedTools.ContainsKey(GameModeDescriptor.ModeId) || !EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId].ContainsKey("BS2") || !String.Equals(EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId], BS2Directory))
-				EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId]["BS2"] = BS2Directory;
+			if (!EnvironmentInfo.Settings.SupportedTools.ContainsKey(GameModeDescriptor.ModeId) || !EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId].ContainsKey("BS2") || !String.Equals(EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId], BSDirectory))
+				EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId]["BS2"] = BSDirectory;
 
 			if (!EnvironmentInfo.Settings.SupportedTools.ContainsKey(GameModeDescriptor.ModeId) || !EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId].ContainsKey("DSRP") || !String.Equals(EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId], DSRPDirectory))
 				EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId]["DSRP"] = DSRPDirectory;

--- a/Skyrim/Settings/UI/SupportedToolsSettingsPage.cs
+++ b/Skyrim/Settings/UI/SupportedToolsSettingsPage.cs
@@ -41,7 +41,7 @@ namespace Nexus.Client.Games.Skyrim.Settings.UI
 			BindingHelper.CreateFullBinding(tbxLOOT, () => tbxLOOT.Text, p_stsSettings, () => p_stsSettings.LOOTDirectory);
 			BindingHelper.CreateFullBinding(tbxWryeBashDirectory, () => tbxWryeBashDirectory.Text, p_stsSettings, () => p_stsSettings.WryeBashDirectory);
 			BindingHelper.CreateFullBinding(tbxFNIS, () => tbxFNIS.Text, p_stsSettings, () => p_stsSettings.FNISDirectory);
-			BindingHelper.CreateFullBinding(tbxBS2, () => tbxBS2.Text, p_stsSettings, () => p_stsSettings.BS2Directory);
+			BindingHelper.CreateFullBinding(tbxBS, () => tbxBS.Text, p_stsSettings, () => p_stsSettings.BSDirectory);
 			BindingHelper.CreateFullBinding(tbxTES5Edit, () => tbxTES5Edit.Text, p_stsSettings, () => p_stsSettings.TES5EditDirectory);
 
 			p_stsSettings.Errors.ErrorChanged -= new EventHandler<ErrorEventArguments>(Errors_ErrorChanged);
@@ -51,7 +51,7 @@ namespace Nexus.Client.Games.Skyrim.Settings.UI
 			lblLOOTPrompt.Text = String.Format(lblLOOTPrompt.Text, p_stsSettings.GameModeName);
 			lblWryeBashPrompt.Text = String.Format(lblWryeBashPrompt.Text, p_stsSettings.GameModeName);
 			lblFNISPrompt.Text = String.Format(lblFNISPrompt.Text, p_stsSettings.GameModeName);
-			lblBS2Prompt.Text = String.Format(lblBS2Prompt.Text, p_stsSettings.GameModeName);
+			lblBSPrompt.Text = String.Format(lblBSPrompt.Text, p_stsSettings.GameModeName);
 			lblTES5EditPrompt.Text = String.Format(lblTES5EditPrompt.Text, p_stsSettings.GameModeName);
 		}
 
@@ -73,8 +73,8 @@ namespace Nexus.Client.Games.Skyrim.Settings.UI
 				erpErrors.SetError(butSelectWryeBashDirectory, e.Error);
 			else if (e.Property.Equals(ObjectHelper.GetPropertyName<SupportedToolsSettingsGroup>(x => x.LOOTDirectory)))
 				erpErrors.SetError(butSelectLOOTDirectory, e.Error);
-			else if (e.Property.Equals(ObjectHelper.GetPropertyName<SupportedToolsSettingsGroup>(x => x.BS2Directory)))
-				erpErrors.SetError(butSelectBS2Directory, e.Error);
+			else if (e.Property.Equals(ObjectHelper.GetPropertyName<SupportedToolsSettingsGroup>(x => x.BSDirectory)))
+				erpErrors.SetError(butSelectBSDirectory, e.Error);
 			else if (e.Property.Equals(ObjectHelper.GetPropertyName<SupportedToolsSettingsGroup>(x => x.FNISDirectory)))
 				erpErrors.SetError(butSelectFNISDirectory, e.Error);
 			else if (e.Property.Equals(ObjectHelper.GetPropertyName<SupportedToolsSettingsGroup>(x => x.TES5EditDirectory)))
@@ -171,19 +171,19 @@ namespace Nexus.Client.Games.Skyrim.Settings.UI
 		}
 
 		/// <summary>
-		/// Handles the <see cref="Control.Click"/> event of the selectBS2 button.
+		/// Handles the <see cref="Control.Click"/> event of the selectBS button.
 		/// </summary>
 		/// <remarks>
-		/// This opens the folder selection dialog for BodySlide2.
+		/// This opens the folder selection dialog for BodySlide.
 		/// </remarks>
 		/// <param name="sender">The object that raised the event.</param>
 		/// <param name="e">An <see cref="EventArgs"/> describing the event arguments.</param>
-		private void butSelectBS2Directory_Click(object sender, EventArgs e)
+		private void butSelectBSDirectory_Click(object sender, EventArgs e)
 		{
-			fbdDirectory.SelectedPath = tbxBS2.Text;
+			fbdDirectory.SelectedPath = tbxBS.Text;
 			if (fbdDirectory.ShowDialog(this) == DialogResult.OK)
 			{
-				tbxBS2.Text = fbdDirectory.SelectedPath;
+				tbxBS.Text = fbdDirectory.SelectedPath;
 				//force the data binding on the textbox to push the value to the bound view model
 				ValidateChildren();
 			}

--- a/Skyrim/Settings/UI/SupportedToolsSettingsPage.designer.cs
+++ b/Skyrim/Settings/UI/SupportedToolsSettingsPage.designer.cs
@@ -46,10 +46,10 @@
 			this.lblFNISPrompt = new System.Windows.Forms.Label();
 			this.tbxFNIS = new System.Windows.Forms.TextBox();
 			this.lblFNISLabel = new System.Windows.Forms.Label();
-			this.butSelectBS2Directory = new System.Windows.Forms.Button();
-			this.lblBS2Prompt = new System.Windows.Forms.Label();
-			this.tbxBS2 = new System.Windows.Forms.TextBox();
-			this.lblBS2Label = new System.Windows.Forms.Label();
+			this.butSelectBSDirectory = new System.Windows.Forms.Button();
+			this.lblBSPrompt = new System.Windows.Forms.Label();
+			this.tbxBS = new System.Windows.Forms.TextBox();
+			this.lblBSLabel = new System.Windows.Forms.Label();
 			this.butSelectTES5EditDirectory = new System.Windows.Forms.Button();
 			this.lblTES5EditPrompt = new System.Windows.Forms.Label();
 			this.tbxTES5Edit = new System.Windows.Forms.TextBox();
@@ -219,45 +219,45 @@
 			this.lblFNISLabel.TabIndex = 13;
 			this.lblFNISLabel.Text = "FNIS path:";
 			// 
-			// butSelectBS2Directory
+			// butSelectBSDirectory
 			// 
-			this.butSelectBS2Directory.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.butSelectBS2Directory.AutoSize = true;
-			this.butSelectBS2Directory.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.butSelectBS2Directory.Location = new System.Drawing.Point(394, 229);
-			this.butSelectBS2Directory.Name = "butSelectBS2Directory";
-			this.butSelectBS2Directory.Size = new System.Drawing.Size(26, 23);
-			this.butSelectBS2Directory.TabIndex = 12;
-			this.butSelectBS2Directory.Text = "...";
-			this.butSelectBS2Directory.UseVisualStyleBackColor = true;
-			this.butSelectBS2Directory.Click += new System.EventHandler(this.butSelectBS2Directory_Click);
+			this.butSelectBSDirectory.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+			this.butSelectBSDirectory.AutoSize = true;
+			this.butSelectBSDirectory.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+			this.butSelectBSDirectory.Location = new System.Drawing.Point(394, 229);
+			this.butSelectBSDirectory.Name = "butSelectBSDirectory";
+			this.butSelectBSDirectory.Size = new System.Drawing.Size(26, 23);
+			this.butSelectBSDirectory.TabIndex = 12;
+			this.butSelectBSDirectory.Text = "...";
+			this.butSelectBSDirectory.UseVisualStyleBackColor = true;
+			this.butSelectBSDirectory.Click += new System.EventHandler(this.butSelectBSDirectory_Click);
 			// 
-			// lblBS2Prompt
+			// lblBSPrompt
 			// 
-			this.lblBS2Prompt.AutoSize = true;
-			this.lblBS2Prompt.Location = new System.Drawing.Point(3, 215);
-			this.lblBS2Prompt.Name = "lblBS2Prompt";
-			this.lblBS2Prompt.Size = new System.Drawing.Size(217, 13);
-			this.lblBS2Prompt.TabIndex = 14;
-			this.lblBS2Prompt.Text = "Select the directory where BodySlide 2 is installed:";
+			this.lblBSPrompt.AutoSize = true;
+			this.lblBSPrompt.Location = new System.Drawing.Point(3, 215);
+			this.lblBSPrompt.Name = "lblBSPrompt";
+			this.lblBSPrompt.Size = new System.Drawing.Size(217, 13);
+			this.lblBSPrompt.TabIndex = 14;
+			this.lblBSPrompt.Text = "Select the directory where BodySlide is installed:";
 			// 
-			// tbxBS2
+			// tbxBS
 			// 
-			this.tbxBS2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+			this.tbxBS.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
 						| System.Windows.Forms.AnchorStyles.Right)));
-			this.tbxBS2.Location = new System.Drawing.Point(130, 231);
-			this.tbxBS2.Name = "tbxBS2";
-			this.tbxBS2.Size = new System.Drawing.Size(250, 20);
-			this.tbxBS2.TabIndex = 10;
+			this.tbxBS.Location = new System.Drawing.Point(130, 231);
+			this.tbxBS.Name = "tbxBS";
+			this.tbxBS.Size = new System.Drawing.Size(250, 20);
+			this.tbxBS.TabIndex = 10;
 			// 
-			// lblBS2Label
+			// lblBSLabel
 			// 
-			this.lblBS2Label.AutoSize = true;
-			this.lblBS2Label.Location = new System.Drawing.Point(38, 234);
-			this.lblBS2Label.Name = "lblBS2Label";
-			this.lblBS2Label.Size = new System.Drawing.Size(79, 13);
-			this.lblBS2Label.TabIndex = 13;
-			this.lblBS2Label.Text = "BodySlide2 path:";
+			this.lblBSLabel.AutoSize = true;
+			this.lblBSLabel.Location = new System.Drawing.Point(38, 234);
+			this.lblBSLabel.Name = "lblBSLabel";
+			this.lblBSLabel.Size = new System.Drawing.Size(79, 13);
+			this.lblBSLabel.TabIndex = 13;
+			this.lblBSLabel.Text = "BodySlide path:";
 			// 
 			// butSelectTES5EditDirectory
 			// 
@@ -338,10 +338,10 @@
 			this.Controls.Add(this.lblTES5EditPrompt);
 			this.Controls.Add(this.tbxTES5Edit);
 			this.Controls.Add(this.lblTES5EditLabel);
-			this.Controls.Add(this.butSelectBS2Directory);
-			this.Controls.Add(this.lblBS2Prompt);
-			this.Controls.Add(this.tbxBS2);
-			this.Controls.Add(this.lblBS2Label);
+			this.Controls.Add(this.butSelectBSDirectory);
+			this.Controls.Add(this.lblBSPrompt);
+			this.Controls.Add(this.tbxBS);
+			this.Controls.Add(this.lblBSLabel);
 			this.Name = "SupportedToolsSettingsPage";
 			this.Size = new System.Drawing.Size(443, 405);
 			((System.ComponentModel.ISupportInitialize)(this.erpErrors)).EndInit();
@@ -368,10 +368,10 @@
 		private System.Windows.Forms.Label lblFNISPrompt;
 		private System.Windows.Forms.TextBox tbxFNIS;
 		private System.Windows.Forms.Label lblFNISLabel;
-		private System.Windows.Forms.Button butSelectBS2Directory;
-		private System.Windows.Forms.Label lblBS2Prompt;
-		private System.Windows.Forms.TextBox tbxBS2;
-		private System.Windows.Forms.Label lblBS2Label;
+		private System.Windows.Forms.Button butSelectBSDirectory;
+		private System.Windows.Forms.Label lblBSPrompt;
+		private System.Windows.Forms.TextBox tbxBS;
+		private System.Windows.Forms.Label lblBSLabel;
 		private System.Windows.Forms.Button butSelectTES5EditDirectory;
 		private System.Windows.Forms.Label lblTES5EditPrompt;
 		private System.Windows.Forms.TextBox tbxTES5Edit;

--- a/Skyrim/SkyrimSupportedTools.cs
+++ b/Skyrim/SkyrimSupportedTools.cs
@@ -103,17 +103,17 @@ namespace Nexus.Client.Games.Skyrim
 				AddLaunchCommand(new Command("Config#FNIS", "Config FNIS", "Configures FNIS.", imgIcon, ConfigFNIS, true));
 			}
 
-			strCommand = GetBS2LaunchCommand();
-			Trace.TraceInformation("BodySlide 2 Command: {0} (IsNull={1})", strCommand, (strCommand == null));
+			strCommand = GetBSLaunchCommand();
+			Trace.TraceInformation("BodySlide Command: {0} (IsNull={1})", strCommand, (strCommand == null));
 			if ((strCommand != null) && (File.Exists(strCommand)))
 			{
 				imgIcon = File.Exists(strCommand) ? Icon.ExtractAssociatedIcon(strCommand).ToBitmap() : null;
-				AddLaunchCommand(new Command("BS2", "Launch BodySlide 2", "Launches BodySlide 2.", imgIcon, LaunchBS2, true));
+				AddLaunchCommand(new Command("BS2", "Launch BodySlide", "Launches BodySlide.", imgIcon, LaunchBS, true));
 			}
 			else
 			{
 				imgIcon = null;
-				AddLaunchCommand(new Command("Config#BodySlide 2", "Config BodySlide 2", "Configures BodySlide 2.", imgIcon, ConfigBS2, true));
+				AddLaunchCommand(new Command("Config#BodySlide", "Config BodySlide", "Configures BodySlide.", imgIcon, ConfigBS, true));
 			}
 
 			strCommand = GetDSRPLaunchCommand();
@@ -192,11 +192,11 @@ namespace Nexus.Client.Games.Skyrim
 			Launch(strCommand, null);
 		}
 
-		private void LaunchBS2()
+		private void LaunchBS()
 		{
-			Trace.TraceInformation("Launching BodySlide 2");
+			Trace.TraceInformation("Launching BodySlide");
 			Trace.Indent();
-			string strCommand = GetBS2LaunchCommand();
+			string strCommand = GetBSLaunchCommand();
 			Trace.TraceInformation("Command: " + strCommand);
 			Launch(strCommand, null);
 		}
@@ -392,46 +392,46 @@ namespace Nexus.Client.Games.Skyrim
 		}
 
 		/// <summary>
-		/// Gets the BodySlide 2 launch command.
+		/// Gets the BodySlide launch command.
 		/// </summary>
-		/// <returns>The BodySlide 2 launch command.</returns>
-		private string GetBS2LaunchCommand()
+		/// <returns>The BodySlide launch command.</returns>
+		private string GetBSLaunchCommand()
 		{
-			string strBS2 = String.Empty;
+			string strBS = String.Empty;
 
 			if (EnvironmentInfo.Settings.SupportedTools[GameMode.ModeId].ContainsKey("BS2"))
 			{
-				strBS2 = EnvironmentInfo.Settings.SupportedTools[GameMode.ModeId]["BS2"];
-				if (!String.IsNullOrWhiteSpace(strBS2) && ((strBS2.IndexOfAny(Path.GetInvalidPathChars()) >= 0) || !Directory.Exists(strBS2)))
+				strBS = EnvironmentInfo.Settings.SupportedTools[GameMode.ModeId]["BS2"];
+				if (!String.IsNullOrWhiteSpace(strBS) && ((strBS.IndexOfAny(Path.GetInvalidPathChars()) >= 0) || !Directory.Exists(strBS)))
 				{
-					strBS2 = String.Empty;
+					strBS = String.Empty;
 					EnvironmentInfo.Settings.SupportedTools[GameMode.ModeId]["BS2"] = String.Empty;
 					EnvironmentInfo.Settings.Save();
 				}
 			}
 
-			if (String.IsNullOrEmpty(strBS2))
+			if (String.IsNullOrEmpty(strBS))
 			{
-				string strBS2Path = Path.Combine(GameMode.GameModeEnvironmentInfo.InstallationPath, @"Data\CalienteTools\BodySlide");
-				if (Directory.Exists(strBS2Path))
+				string strBSPath = Path.Combine(GameMode.GameModeEnvironmentInfo.InstallationPath, @"Data\CalienteTools\BodySlide");
+				if (Directory.Exists(strBSPath))
 				{
-					strBS2 = strBS2Path;
-					EnvironmentInfo.Settings.SupportedTools[GameMode.ModeId]["BS2"] = strBS2;
+					strBS = strBSPath;
+					EnvironmentInfo.Settings.SupportedTools[GameMode.ModeId]["BS2"] = strBS;
 					EnvironmentInfo.Settings.Save();
 				}
 			}
 
-			if (!String.IsNullOrEmpty(strBS2))
+			if (!String.IsNullOrEmpty(strBS))
 			{
-				string str64bit = Path.Combine(strBS2, "BodySlide x64.exe");
+				string str64bit = Path.Combine(strBS, "BodySlide x64.exe");
 
 				if (Environment.Is64BitProcess && File.Exists(str64bit))
-					strBS2 = str64bit;
+					strBS = str64bit;
 				else
-					strBS2 = Path.Combine(strBS2, "BodySlide.exe");
+					strBS = Path.Combine(strBS, "BodySlide.exe");
 			}
 
-			return strBS2;
+			return strBS;
 		}
 
 		/// <summary>
@@ -525,7 +525,7 @@ namespace Nexus.Client.Games.Skyrim
 					break;
 
 				case "BS2":
-					ConfigBS2();
+					ConfigBS();
 					break;
 
 				case "TES5Edit":
@@ -703,7 +703,7 @@ namespace Nexus.Client.Games.Skyrim
 				}
 		}
 
-		private void ConfigBS2()
+		private void ConfigBS()
 		{
 			string p_strToolName = "BS2";
 			string p_strExecutableName = "BodySlide.exe";

--- a/SkyrimSE/Settings/SupportedToolsSettingsGroup.cs
+++ b/SkyrimSE/Settings/SupportedToolsSettingsGroup.cs
@@ -21,7 +21,7 @@ namespace Nexus.Client.Games.SkyrimSE
 		private string m_strWryeBashDirectory = null;
 		private string m_strFNISDirectory = null;
 		private string m_strSSEEditDirectory = null;
-		private string m_strBS2Directory = null;
+		private string m_strBSDirectory = null;
 		private string m_strDSRPDirectory = null;
 		private string m_strPMDirectory = null;
 
@@ -122,18 +122,18 @@ namespace Nexus.Client.Games.SkyrimSE
 		}
 
 		/// <summary>
-		/// Gets or sets the path of the directory where BodySlide2 is installed.
+		/// Gets or sets the path of the directory where BodySlide is installed.
 		/// </summary>
-		/// <value>The path of the directory where BodySlide2 is installed.</value>
-		public string BS2Directory
+		/// <value>The path of the directory where BodySlide is installed.</value>
+		public string BSDirectory
 		{
 			get
 			{
-				return m_strBS2Directory;
+				return m_strBSDirectory;
 			}
 			set
 			{
-				SetPropertyIfChanged(ref m_strBS2Directory, value, () => BS2Directory);
+				SetPropertyIfChanged(ref m_strBSDirectory, value, () => BSDirectory);
 			}
 		}
 
@@ -211,7 +211,7 @@ namespace Nexus.Client.Games.SkyrimSE
 		/// </summary>
 		/// <returns><c>true</c> if the specified directory are not equals;
 		/// <c>false</c> otherwise.</returns>
-		protected bool ValidateDirectory(string p_strBOSSPath, string p_strBOSSPathName, string p_strBOSSProperty, string p_strWryeBashPath, string p_strWryeBashPathName, string p_strWryeBashProperty, string p_strFNISPath, string p_strFNISPathName, string p_strFNISProperty, string p_strBS2Path, string p_strBS2PathName, string p_strBS2Property, string p_strLOOTPath, string p_strLOOTPathName, string p_strLOOTProperty, string p_strSSEEditPath, string p_strSSEEditPathName, string p_strSSEEditProperty, string p_strDSRPPath, string p_strDSRPPathName, string p_strDSRPProperty, string p_strPMPath, string p_strPMPathName, string p_strPMProperty)
+		protected bool ValidateDirectory(string p_strBOSSPath, string p_strBOSSPathName, string p_strBOSSProperty, string p_strWryeBashPath, string p_strWryeBashPathName, string p_strWryeBashProperty, string p_strFNISPath, string p_strFNISPathName, string p_strFNISProperty, string p_strBSPath, string p_strBSPathName, string p_strBSProperty, string p_strLOOTPath, string p_strLOOTPathName, string p_strLOOTProperty, string p_strSSEEditPath, string p_strSSEEditPathName, string p_strSSEEditProperty, string p_strDSRPPath, string p_strDSRPPathName, string p_strDSRPProperty, string p_strPMPath, string p_strPMPathName, string p_strPMProperty)
 		{
 			Errors.Clear(p_strBOSSProperty);
 			if (String.IsNullOrEmpty(p_strBOSSPath))
@@ -231,10 +231,10 @@ namespace Nexus.Client.Games.SkyrimSE
 				Errors.SetError(p_strFNISProperty, String.Format("You must select a {0}.", p_strFNISPathName));
 				return false;
 			}
-			Errors.Clear(p_strBS2Property);
-			if (String.IsNullOrEmpty(p_strBS2Path))
+			Errors.Clear(p_strBSProperty);
+			if (String.IsNullOrEmpty(p_strBSPath))
 			{
-				Errors.SetError(p_strBS2Property, String.Format("You must select a {0}.", p_strBS2PathName));
+				Errors.SetError(p_strBSProperty, String.Format("You must select a {0}.", p_strBSPathName));
 				return false;
 			}
 			Errors.Clear(p_strDSRPProperty);
@@ -350,13 +350,13 @@ namespace Nexus.Client.Games.SkyrimSE
 		}
 
 		/// <summary>
-		/// Validates the selected BodySlide2 directory.
+		/// Validates the selected BodySlide directory.
 		/// </summary>
-		/// <returns><c>true</c> if the selected BodySlide2 directory is valid;
+		/// <returns><c>true</c> if the selected BodySlide directory is valid;
 		/// <c>false</c> otherwise.</returns>
-		protected bool ValidateBS2Directory()
+		protected bool ValidateBSDirectory()
 		{
-			return ValidateDirectory(BS2Directory, "BodySlide2 Directory", ObjectHelper.GetPropertyName(() => BS2Directory));
+			return ValidateDirectory(BSDirectory, "BodySlide Directory", ObjectHelper.GetPropertyName(() => BSDirectory));
 		}
 
 		/// <summary>
@@ -396,7 +396,7 @@ namespace Nexus.Client.Games.SkyrimSE
 		/// <c>false</c> otherwise.</returns>
 		public bool ValidateSettings()
 		{
-			return ValidateBOSSDirectory() && ValidateLOOTDirectory() && ValidateWryeBashDirectory() && ValidateFNISDirectory() && ValidateSSEEditDirectory() && ValidatePMDirectory() && ValidateDSRPDirectory() && ValidateBS2Directory();
+			return ValidateBOSSDirectory() && ValidateLOOTDirectory() && ValidateWryeBashDirectory() && ValidateFNISDirectory() && ValidateSSEEditDirectory() && ValidatePMDirectory() && ValidateDSRPDirectory() && ValidateBSDirectory();
 		}
 
 		#endregion
@@ -412,7 +412,7 @@ namespace Nexus.Client.Games.SkyrimSE
 			string strLOOTReg = String.Empty;
 			string strWryePath = String.Empty;
 			string strFNISPath = String.Empty;
-			string strBS2Path = String.Empty;
+			string strBSPath = String.Empty;
 			string strDSRPPath = String.Empty;
 			string strPMPath = String.Empty;
 			string strSSEEditPath = String.Empty;
@@ -508,15 +508,15 @@ namespace Nexus.Client.Games.SkyrimSE
 
 			if (EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId].ContainsKey("BS2"))
 			{
-				strBS2Path = EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId]["BS2"];
+				strBSPath = EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId]["BS2"];
 
-				if (String.IsNullOrEmpty(strBS2Path))
+				if (String.IsNullOrEmpty(strBSPath))
 				{
 					booReset = true;
 				}
-				else if (Directory.Exists(strBS2Path) || File.Exists(strBS2Path))
+				else if (Directory.Exists(strBSPath) || File.Exists(strBSPath))
 				{
-					FileAttributes attr = File.GetAttributes(strBS2Path);
+					FileAttributes attr = File.GetAttributes(strBSPath);
 					booReset = !attr.HasFlag(FileAttributes.Directory);
 				}
 				else
@@ -524,17 +524,17 @@ namespace Nexus.Client.Games.SkyrimSE
 
 				if (booReset)
 				{
-					string strBS2 = Path.Combine(GameModeDescriptor.InstallationPath, @"Data\CalienteTools\BodySlide");
-					if (Directory.Exists(strBS2))
-						strBS2Path = strBS2;
+					string strBS = Path.Combine(GameModeDescriptor.InstallationPath, @"Data\CalienteTools\BodySlide");
+					if (Directory.Exists(strBS))
+						strBSPath = strBS;
 					else
-						strBS2Path = String.Empty;
+						strBSPath = String.Empty;
 
 					booReset = false;
 				}
 
-				if (!String.IsNullOrEmpty(strBS2Path) && Directory.Exists(strBS2Path))
-					BS2Directory = strBS2Path;
+				if (!String.IsNullOrEmpty(strBSPath) && Directory.Exists(strBSPath))
+					BSDirectory = strBSPath;
 			}
 
 			if (EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId].ContainsKey("DSRP"))
@@ -631,8 +631,8 @@ namespace Nexus.Client.Games.SkyrimSE
 			if (!EnvironmentInfo.Settings.SupportedTools.ContainsKey(GameModeDescriptor.ModeId) || !EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId].ContainsKey("FNIS") || !String.Equals(EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId], FNISDirectory))
 				EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId]["FNIS"] = FNISDirectory;
 
-			if (!EnvironmentInfo.Settings.SupportedTools.ContainsKey(GameModeDescriptor.ModeId) || !EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId].ContainsKey("BS2") || !String.Equals(EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId], BS2Directory))
-				EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId]["BS2"] = BS2Directory;
+			if (!EnvironmentInfo.Settings.SupportedTools.ContainsKey(GameModeDescriptor.ModeId) || !EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId].ContainsKey("BS2") || !String.Equals(EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId], BSDirectory))
+				EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId]["BS2"] = BSDirectory;
 
 			if (!EnvironmentInfo.Settings.SupportedTools.ContainsKey(GameModeDescriptor.ModeId) || !EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId].ContainsKey("DSRP") || !String.Equals(EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId], DSRPDirectory))
 				EnvironmentInfo.Settings.SupportedTools[GameModeDescriptor.ModeId]["DSRP"] = DSRPDirectory;

--- a/SkyrimSE/Settings/UI/SupportedToolsSettingsPage.cs
+++ b/SkyrimSE/Settings/UI/SupportedToolsSettingsPage.cs
@@ -41,7 +41,7 @@ namespace Nexus.Client.Games.SkyrimSE.Settings.UI
 			BindingHelper.CreateFullBinding(tbxLOOT, () => tbxLOOT.Text, p_stsSettings, () => p_stsSettings.LOOTDirectory);
 			BindingHelper.CreateFullBinding(tbxWryeBashDirectory, () => tbxWryeBashDirectory.Text, p_stsSettings, () => p_stsSettings.WryeBashDirectory);
 			BindingHelper.CreateFullBinding(tbxFNIS, () => tbxFNIS.Text, p_stsSettings, () => p_stsSettings.FNISDirectory);
-			BindingHelper.CreateFullBinding(tbxBS2, () => tbxBS2.Text, p_stsSettings, () => p_stsSettings.BS2Directory);
+			BindingHelper.CreateFullBinding(tbxBS, () => tbxBS.Text, p_stsSettings, () => p_stsSettings.BSDirectory);
 			BindingHelper.CreateFullBinding(tbxSSEEdit, () => tbxSSEEdit.Text, p_stsSettings, () => p_stsSettings.SSEEditDirectory);
 
 			p_stsSettings.Errors.ErrorChanged -= new EventHandler<ErrorEventArguments>(Errors_ErrorChanged);
@@ -51,7 +51,7 @@ namespace Nexus.Client.Games.SkyrimSE.Settings.UI
 			lblLOOTPrompt.Text = String.Format(lblLOOTPrompt.Text, p_stsSettings.GameModeName);
 			lblWryeBashPrompt.Text = String.Format(lblWryeBashPrompt.Text, p_stsSettings.GameModeName);
 			lblFNISPrompt.Text = String.Format(lblFNISPrompt.Text, p_stsSettings.GameModeName);
-			lblBS2Prompt.Text = String.Format(lblBS2Prompt.Text, p_stsSettings.GameModeName);
+			lblBSPrompt.Text = String.Format(lblBSPrompt.Text, p_stsSettings.GameModeName);
 			lblSSEEditPrompt.Text = String.Format(lblSSEEditPrompt.Text, p_stsSettings.GameModeName);
 		}
 
@@ -73,8 +73,8 @@ namespace Nexus.Client.Games.SkyrimSE.Settings.UI
 				erpErrors.SetError(butSelectWryeBashDirectory, e.Error);
 			else if (e.Property.Equals(ObjectHelper.GetPropertyName<SupportedToolsSettingsGroup>(x => x.LOOTDirectory)))
 				erpErrors.SetError(butSelectLOOTDirectory, e.Error);
-			else if (e.Property.Equals(ObjectHelper.GetPropertyName<SupportedToolsSettingsGroup>(x => x.BS2Directory)))
-				erpErrors.SetError(butSelectBS2Directory, e.Error);
+			else if (e.Property.Equals(ObjectHelper.GetPropertyName<SupportedToolsSettingsGroup>(x => x.BSDirectory)))
+				erpErrors.SetError(butSelectBSDirectory, e.Error);
 			else if (e.Property.Equals(ObjectHelper.GetPropertyName<SupportedToolsSettingsGroup>(x => x.FNISDirectory)))
 				erpErrors.SetError(butSelectFNISDirectory, e.Error);
 			else if (e.Property.Equals(ObjectHelper.GetPropertyName<SupportedToolsSettingsGroup>(x => x.SSEEditDirectory)))
@@ -171,19 +171,19 @@ namespace Nexus.Client.Games.SkyrimSE.Settings.UI
 		}
 
 		/// <summary>
-		/// Handles the <see cref="Control.Click"/> event of the selectBS2 button.
+		/// Handles the <see cref="Control.Click"/> event of the selectBS button.
 		/// </summary>
 		/// <remarks>
-		/// This opens the folder selection dialog for BodySlide2.
+		/// This opens the folder selection dialog for BodySlide.
 		/// </remarks>
 		/// <param name="sender">The object that raised the event.</param>
 		/// <param name="e">An <see cref="EventArgs"/> describing the event arguments.</param>
-		private void butSelectBS2Directory_Click(object sender, EventArgs e)
+		private void butSelectBSDirectory_Click(object sender, EventArgs e)
 		{
-			fbdDirectory.SelectedPath = tbxBS2.Text;
+			fbdDirectory.SelectedPath = tbxBS.Text;
 			if (fbdDirectory.ShowDialog(this) == DialogResult.OK)
 			{
-				tbxBS2.Text = fbdDirectory.SelectedPath;
+				tbxBS.Text = fbdDirectory.SelectedPath;
 				//force the data binding on the textbox to push the value to the bound view model
 				ValidateChildren();
 			}

--- a/SkyrimSE/Settings/UI/SupportedToolsSettingsPage.designer.cs
+++ b/SkyrimSE/Settings/UI/SupportedToolsSettingsPage.designer.cs
@@ -46,10 +46,10 @@
 			this.lblFNISPrompt = new System.Windows.Forms.Label();
 			this.tbxFNIS = new System.Windows.Forms.TextBox();
 			this.lblFNISLabel = new System.Windows.Forms.Label();
-			this.butSelectBS2Directory = new System.Windows.Forms.Button();
-			this.lblBS2Prompt = new System.Windows.Forms.Label();
-			this.tbxBS2 = new System.Windows.Forms.TextBox();
-			this.lblBS2Label = new System.Windows.Forms.Label();
+			this.butSelectBSDirectory = new System.Windows.Forms.Button();
+			this.lblBSPrompt = new System.Windows.Forms.Label();
+			this.tbxBS = new System.Windows.Forms.TextBox();
+			this.lblBSLabel = new System.Windows.Forms.Label();
 			this.butSelectSSEEditDirectory = new System.Windows.Forms.Button();
 			this.lblSSEEditPrompt = new System.Windows.Forms.Label();
 			this.tbxSSEEdit = new System.Windows.Forms.TextBox();
@@ -219,45 +219,45 @@
 			this.lblFNISLabel.TabIndex = 13;
 			this.lblFNISLabel.Text = "FNIS path:";
 			// 
-			// butSelectBS2Directory
+			// butSelectBSDirectory
 			// 
-			this.butSelectBS2Directory.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.butSelectBS2Directory.AutoSize = true;
-			this.butSelectBS2Directory.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.butSelectBS2Directory.Location = new System.Drawing.Point(394, 229);
-			this.butSelectBS2Directory.Name = "butSelectBS2Directory";
-			this.butSelectBS2Directory.Size = new System.Drawing.Size(26, 23);
-			this.butSelectBS2Directory.TabIndex = 12;
-			this.butSelectBS2Directory.Text = "...";
-			this.butSelectBS2Directory.UseVisualStyleBackColor = true;
-			this.butSelectBS2Directory.Click += new System.EventHandler(this.butSelectBS2Directory_Click);
+			this.butSelectBSDirectory.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+			this.butSelectBSDirectory.AutoSize = true;
+			this.butSelectBSDirectory.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+			this.butSelectBSDirectory.Location = new System.Drawing.Point(394, 229);
+			this.butSelectBSDirectory.Name = "butSelectBSDirectory";
+			this.butSelectBSDirectory.Size = new System.Drawing.Size(26, 23);
+			this.butSelectBSDirectory.TabIndex = 12;
+			this.butSelectBSDirectory.Text = "...";
+			this.butSelectBSDirectory.UseVisualStyleBackColor = true;
+			this.butSelectBSDirectory.Click += new System.EventHandler(this.butSelectBSDirectory_Click);
 			// 
-			// lblBS2Prompt
+			// lblBSPrompt
 			// 
-			this.lblBS2Prompt.AutoSize = true;
-			this.lblBS2Prompt.Location = new System.Drawing.Point(3, 215);
-			this.lblBS2Prompt.Name = "lblBS2Prompt";
-			this.lblBS2Prompt.Size = new System.Drawing.Size(217, 13);
-			this.lblBS2Prompt.TabIndex = 14;
-			this.lblBS2Prompt.Text = "Select the directory where BodySlide 2 is installed:";
+			this.lblBSPrompt.AutoSize = true;
+			this.lblBSPrompt.Location = new System.Drawing.Point(3, 215);
+			this.lblBSPrompt.Name = "lblBSPrompt";
+			this.lblBSPrompt.Size = new System.Drawing.Size(217, 13);
+			this.lblBSPrompt.TabIndex = 14;
+			this.lblBSPrompt.Text = "Select the directory where BodySlide is installed:";
 			// 
-			// tbxBS2
+			// tbxBS
 			// 
-			this.tbxBS2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+			this.tbxBS.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
 						| System.Windows.Forms.AnchorStyles.Right)));
-			this.tbxBS2.Location = new System.Drawing.Point(130, 231);
-			this.tbxBS2.Name = "tbxBS2";
-			this.tbxBS2.Size = new System.Drawing.Size(250, 20);
-			this.tbxBS2.TabIndex = 10;
+			this.tbxBS.Location = new System.Drawing.Point(130, 231);
+			this.tbxBS.Name = "tbxBS";
+			this.tbxBS.Size = new System.Drawing.Size(250, 20);
+			this.tbxBS.TabIndex = 10;
 			// 
-			// lblBS2Label
+			// lblBSLabel
 			// 
-			this.lblBS2Label.AutoSize = true;
-			this.lblBS2Label.Location = new System.Drawing.Point(38, 234);
-			this.lblBS2Label.Name = "lblBS2Label";
-			this.lblBS2Label.Size = new System.Drawing.Size(79, 13);
-			this.lblBS2Label.TabIndex = 13;
-			this.lblBS2Label.Text = "BodySlide2 path:";
+			this.lblBSLabel.AutoSize = true;
+			this.lblBSLabel.Location = new System.Drawing.Point(38, 234);
+			this.lblBSLabel.Name = "lblBSLabel";
+			this.lblBSLabel.Size = new System.Drawing.Size(79, 13);
+			this.lblBSLabel.TabIndex = 13;
+			this.lblBSLabel.Text = "BodySlide path:";
 			// 
 			// butSelectSSEEditDirectory
 			// 
@@ -338,10 +338,10 @@
 			this.Controls.Add(this.lblSSEEditPrompt);
 			this.Controls.Add(this.tbxSSEEdit);
 			this.Controls.Add(this.lblSSEEditLabel);
-			this.Controls.Add(this.butSelectBS2Directory);
-			this.Controls.Add(this.lblBS2Prompt);
-			this.Controls.Add(this.tbxBS2);
-			this.Controls.Add(this.lblBS2Label);
+			this.Controls.Add(this.butSelectBSDirectory);
+			this.Controls.Add(this.lblBSPrompt);
+			this.Controls.Add(this.tbxBS);
+			this.Controls.Add(this.lblBSLabel);
 			this.Name = "SupportedToolsSettingsPage";
 			this.Size = new System.Drawing.Size(443, 405);
 			((System.ComponentModel.ISupportInitialize)(this.erpErrors)).EndInit();
@@ -368,10 +368,10 @@
 		private System.Windows.Forms.Label lblFNISPrompt;
 		private System.Windows.Forms.TextBox tbxFNIS;
 		private System.Windows.Forms.Label lblFNISLabel;
-		private System.Windows.Forms.Button butSelectBS2Directory;
-		private System.Windows.Forms.Label lblBS2Prompt;
-		private System.Windows.Forms.TextBox tbxBS2;
-		private System.Windows.Forms.Label lblBS2Label;
+		private System.Windows.Forms.Button butSelectBSDirectory;
+		private System.Windows.Forms.Label lblBSPrompt;
+		private System.Windows.Forms.TextBox tbxBS;
+		private System.Windows.Forms.Label lblBSLabel;
 		private System.Windows.Forms.Button butSelectSSEEditDirectory;
 		private System.Windows.Forms.Label lblSSEEditPrompt;
 		private System.Windows.Forms.TextBox tbxSSEEdit;

--- a/SkyrimSE/SkyrimSESupportedTools.cs
+++ b/SkyrimSE/SkyrimSESupportedTools.cs
@@ -103,17 +103,17 @@ namespace Nexus.Client.Games.SkyrimSE
 				AddLaunchCommand(new Command("Config#FNIS", "Config FNIS", "Configures FNIS.", imgIcon, ConfigFNIS, true));
 			}
 
-			strCommand = GetBS2LaunchCommand();
-			Trace.TraceInformation("BodySlide 2 Command: {0} (IsNull={1})", strCommand, (strCommand == null));
+			strCommand = GetBSLaunchCommand();
+			Trace.TraceInformation("BodySlide Command: {0} (IsNull={1})", strCommand, (strCommand == null));
 			if ((strCommand != null) && (File.Exists(strCommand)))
 			{
 				imgIcon = File.Exists(strCommand) ? Icon.ExtractAssociatedIcon(strCommand).ToBitmap() : null;
-				AddLaunchCommand(new Command("BS2", "Launch BodySlide 2", "Launches BodySlide 2.", imgIcon, LaunchBS2, true));
+				AddLaunchCommand(new Command("BS2", "Launch BodySlide", "Launches BodySlide.", imgIcon, LaunchBS, true));
 			}
 			else
 			{
 				imgIcon = null;
-				AddLaunchCommand(new Command("Config#BodySlide 2", "Config BodySlide 2", "Configures BodySlide 2.", imgIcon, ConfigBS2, true));
+				AddLaunchCommand(new Command("Config#BodySlide", "Config BodySlide", "Configures BodySlide.", imgIcon, ConfigBS, true));
 			}
 
 			strCommand = GetDSRPLaunchCommand();
@@ -192,11 +192,11 @@ namespace Nexus.Client.Games.SkyrimSE
 			Launch(strCommand, null);
 		}
 
-		private void LaunchBS2()
+		private void LaunchBS()
 		{
-			Trace.TraceInformation("Launching BodySlide 2");
+			Trace.TraceInformation("Launching BodySlide");
 			Trace.Indent();
-			string strCommand = GetBS2LaunchCommand();
+			string strCommand = GetBSLaunchCommand();
 			Trace.TraceInformation("Command: " + strCommand);
 			Launch(strCommand, null);
 		}
@@ -392,46 +392,46 @@ namespace Nexus.Client.Games.SkyrimSE
 		}
 
 		/// <summary>
-		/// Gets the BodySlide 2 launch command.
+		/// Gets the BodySlide launch command.
 		/// </summary>
-		/// <returns>The BodySlide 2 launch command.</returns>
-		private string GetBS2LaunchCommand()
+		/// <returns>The BodySlide launch command.</returns>
+		private string GetBSLaunchCommand()
 		{
-			string strBS2 = String.Empty;
+			string strBS = String.Empty;
 
 			if (EnvironmentInfo.Settings.SupportedTools[GameMode.ModeId].ContainsKey("BS2"))
 			{
-				strBS2 = EnvironmentInfo.Settings.SupportedTools[GameMode.ModeId]["BS2"];
-				if (!String.IsNullOrWhiteSpace(strBS2) && ((strBS2.IndexOfAny(Path.GetInvalidPathChars()) >= 0) || !Directory.Exists(strBS2)))
+				strBS = EnvironmentInfo.Settings.SupportedTools[GameMode.ModeId]["BS2"];
+				if (!String.IsNullOrWhiteSpace(strBS) && ((strBS.IndexOfAny(Path.GetInvalidPathChars()) >= 0) || !Directory.Exists(strBS)))
 				{
-					strBS2 = String.Empty;
+					strBS = String.Empty;
 					EnvironmentInfo.Settings.SupportedTools[GameMode.ModeId]["BS2"] = String.Empty;
 					EnvironmentInfo.Settings.Save();
 				}
 			}
 
-			if (String.IsNullOrEmpty(strBS2))
+			if (String.IsNullOrEmpty(strBS))
 			{
-				string strBS2Path = Path.Combine(GameMode.GameModeEnvironmentInfo.InstallationPath, @"Data\CalienteTools\BodySlide");
-				if (Directory.Exists(strBS2Path))
+				string strBSPath = Path.Combine(GameMode.GameModeEnvironmentInfo.InstallationPath, @"Data\CalienteTools\BodySlide");
+				if (Directory.Exists(strBSPath))
 				{
-					strBS2 = strBS2Path;
-					EnvironmentInfo.Settings.SupportedTools[GameMode.ModeId]["BS2"] = strBS2;
+					strBS = strBSPath;
+					EnvironmentInfo.Settings.SupportedTools[GameMode.ModeId]["BS2"] = strBS;
 					EnvironmentInfo.Settings.Save();
 				}
 			}
 
-			if (!String.IsNullOrEmpty(strBS2))
+			if (!String.IsNullOrEmpty(strBS))
 			{
-				string str64bit = Path.Combine(strBS2, "BodySlide x64.exe");
+				string str64bit = Path.Combine(strBS, "BodySlide x64.exe");
 
 				if (Environment.Is64BitProcess && File.Exists(str64bit))
-					strBS2 = str64bit;
+					strBS = str64bit;
 				else
-					strBS2 = Path.Combine(strBS2, "BodySlide.exe");
+					strBS = Path.Combine(strBS, "BodySlide.exe");
 			}
 
-			return strBS2;
+			return strBS;
 		}
 
 		/// <summary>
@@ -525,7 +525,7 @@ namespace Nexus.Client.Games.SkyrimSE
 					break;
 
 				case "BS2":
-					ConfigBS2();
+					ConfigBS();
 					break;
 
 				case "SSEEdit":
@@ -703,7 +703,7 @@ namespace Nexus.Client.Games.SkyrimSE
 				}
 		}
 
-		private void ConfigBS2()
+		private void ConfigBS()
 		{
 			string p_strToolName = "BS2";
 			string p_strExecutableName = "BodySlide.exe";


### PR DESCRIPTION
Additionally renamed all occurences of "BodySlide 2", "BodySlide2" and
"BS2" to "BodySlide" and "BS" (except for the configuration keys).

The path was "Data\CalienteTools\BodySlide" for FO4, but the correct one is "Data\Tools\BodySlide".
SK and SSE are correct with "CalienteTools".