### PR TITLE
Fixes profile manager not switching properly profiles

### DIFF
--- a/NexusClient/ModManagement/VirtualModActivator/VirtualModActivator.cs
+++ b/NexusClient/ModManagement/VirtualModActivator/VirtualModActivator.cs
@@ -394,7 +394,7 @@ namespace Nexus.Client.ModManagement
 			Version FileVersion = ReadVersion(p_strFilePath);
 
 			if (!string.Equals(p_strFilePath, m_strVirtualActivatorConfigPath, StringComparison.OrdinalIgnoreCase))
-				if (FileVersion.CompareTo(new Version("99.99.99.99")) < 0)
+				if (!(FileVersion.CompareTo(new Version("99.99.99.99")) < 0))
 				{
 					SaveModList(p_strFilePath);
 					return null;


### PR DESCRIPTION
This commit fixes the issue that when changing profiles the profile to be loaded being overwritten. The check was inverted. According to what I saw in the source, this version number gets set when an error happens, and not, if everything is is fine.