### PR TITLE
Adding abilty to add multiple files instead of once at a time

### DIFF
--- a/NexusClient/ModManagement/UI/ModManagerControl.cs
+++ b/NexusClient/ModManagement/UI/ModManagerControl.cs
@@ -385,7 +385,8 @@ namespace Nexus.Client.ModManagement.UI
 				}
 			}
 			stbModTypesDesc.Append(")|");
-			ofdChooseMod.Filter = stbModTypesDesc.ToString() + stbModTypesFilter.ToString() + "|All Files (*.*)|*.*";
+            ofdChooseMod.Filter = stbModTypesDesc.ToString() + stbModTypesFilter.ToString() + "|All Files (*.*)|*.*";
+            ofdChooseMod.Multiselect = true;
 		}
 
 		/// <summary>
@@ -1473,8 +1474,12 @@ namespace Nexus.Client.ModManagement.UI
 		/// <param name="e">An <see cref="EventArgs"/> describing the event arguments.</param>
 		private void addModToolStripMenuItem_Click(object sender, EventArgs e)
 		{
-			if (ofdChooseMod.ShowDialog() == DialogResult.OK)
-				ViewModel.AddModCommand.Execute(ofdChooseMod.FileName);
+            
+            if (ofdChooseMod.ShowDialog() == DialogResult.OK)
+                foreach (string File in ofdChooseMod.FileNames)
+                {
+                    ViewModel.AddModCommand.Execute(File);
+                }
 		}
 
 		/// <summary>


### PR DESCRIPTION
I've tested and works with Skyrim, the Lovers-Lab users can rejoice now since you won't have to add the archives one at a time, this change is so simple I'm a bit shocked it wasn't added to begin with.

This is a rough implementation, but I can't see why it won't work. You just click on the green plus like normal and done.