### PR TITLE
ESL additions

### DIFF
--- a/GamebryoBase/GamebryoGameModeBase.cs
+++ b/GamebryoBase/GamebryoGameModeBase.cs
@@ -463,9 +463,10 @@ namespace Nexus.Client.Games.Gamebryo
 		public override bool HardlinkRequiredFilesType(string p_strFileName)
 		{
 			string strFileType = Path.GetExtension(p_strFileName);
-			return (strFileType.Equals(".esp", StringComparison.InvariantCultureIgnoreCase) || strFileType.Equals(".esm", StringComparison.InvariantCultureIgnoreCase) || strFileType.Equals(".bsa", StringComparison.InvariantCultureIgnoreCase) 
-				|| strFileType.Equals(".mp3", StringComparison.InvariantCultureIgnoreCase) || strFileType.Equals(".BGSM", StringComparison.InvariantCultureIgnoreCase) || strFileType.Equals(".BGEM", StringComparison.InvariantCultureIgnoreCase)
-				|| strFileType.Equals(".wav", StringComparison.InvariantCultureIgnoreCase) || strFileType.Equals(".ogg", StringComparison.InvariantCultureIgnoreCase) || strFileType.Equals(".xwm", StringComparison.InvariantCultureIgnoreCase));
+			return (strFileType.Equals(".esp", StringComparison.InvariantCultureIgnoreCase) || strFileType.Equals(".esl", StringComparison.InvariantCultureIgnoreCase) || strFileType.Equals(".esm", StringComparison.InvariantCultureIgnoreCase)
+				|| strFileType.Equals(".bsa", StringComparison.InvariantCultureIgnoreCase) || strFileType.Equals(".mp3", StringComparison.InvariantCultureIgnoreCase) || strFileType.Equals(".BGSM", StringComparison.InvariantCultureIgnoreCase)
+				|| strFileType.Equals(".BGEM", StringComparison.InvariantCultureIgnoreCase) || strFileType.Equals(".wav", StringComparison.InvariantCultureIgnoreCase) || strFileType.Equals(".ogg", StringComparison.InvariantCultureIgnoreCase)
+				|| strFileType.Equals(".xwm", StringComparison.InvariantCultureIgnoreCase));
 		}
 
 		/// <summary>

--- a/GamebryoBase/GamebryoGameModeDescriptorBase.cs
+++ b/GamebryoBase/GamebryoGameModeDescriptorBase.cs
@@ -10,7 +10,7 @@ namespace Nexus.Client.Games.Gamebryo
 	/// </summary>
 	public abstract class GamebryoGameModeDescriptorBase : GameModeDescriptorBase
 	{
-		private static readonly List<string> PLUGIN_EXTENSIONS = new List<string>() { ".esm", ".esp", ".bsa" };
+		private static readonly List<string> PLUGIN_EXTENSIONS = new List<string>() { ".esm", ".esl", ".esp", ".bsa" };
 		private static readonly List<string> STOP_FOLDERS = new List<string>() { "textures",
 																					"meshes", "music", "shaders", "video", "interface",
 																					"facegen", "menus", "lodsettings", "lsdata",

--- a/GamebryoBase/PluginManagement/GamebryoPluginDiscoverer.cs
+++ b/GamebryoBase/PluginManagement/GamebryoPluginDiscoverer.cs
@@ -11,7 +11,7 @@ namespace Nexus.Client.Games.Gamebryo.PluginManagement
 	/// </summary>
 	public class GamebryoPluginDiscoverer : IPluginDiscoverer
 	{
-		private static string[] PLUGIN_EXTENSIONS = new string[] { ".esp", ".esm" };
+		private static string[] PLUGIN_EXTENSIONS = new string[] { ".esp", ".esl", ".esm" };
 
 		#region Properties
 

--- a/GamebryoBase/PluginManagement/GamebryoPluginFactory.cs
+++ b/GamebryoBase/PluginManagement/GamebryoPluginFactory.cs
@@ -74,7 +74,7 @@ namespace Nexus.Client.Games.Gamebryo.PluginManagement
 			if (tpgPlugin == null || tpgPlugin.Records.Count == 0 || (tpgPlugin.Records[0].Name != "TES4" && tpgPlugin.Records[0].Name != "TES3"))
 			{
 				string strDescription = strPluginName + Environment.NewLine + "Warning: Plugin appears corrupt";
-				return new GamebryoPlugin(p_strPluginPath, strDescription, null, false);
+				return new GamebryoPlugin(p_strPluginPath, strDescription, null, false, false);
 			}
 
 			StringBuilder stbDescription = new StringBuilder();
@@ -160,7 +160,7 @@ namespace Nexus.Client.Games.Gamebryo.PluginManagement
 				catch { }
 			}
 
-			Plugin pifInfo = new GamebryoPlugin(p_strPluginPath, stbDescription.ToString(), imgPicture, (intIsMaster == 1));
+			Plugin pifInfo = new GamebryoPlugin(p_strPluginPath, stbDescription.ToString(), imgPicture, (intIsMaster == 1), (intIsLightMaster == 512));
 			pifInfo.SetMasters(masters);
 
 			return pifInfo;

--- a/GamebryoBase/PluginManagement/GamebryoPluginFactory.cs
+++ b/GamebryoBase/PluginManagement/GamebryoPluginFactory.cs
@@ -103,14 +103,18 @@ namespace Nexus.Client.Games.Gamebryo.PluginManagement
 			}
 
 			uint intIsMaster = 0;
+			uint intIsLightMaster = 0;
 			if (tpgPlugin.Records[0].Name == "TES4")
+			{
 				intIsMaster = ((Record)tpgPlugin.Records[0]).Flags1 & 1;
+			    intIsLightMaster = ((Record)tpgPlugin.Records[0]).Flags1 & 512;
+			}
 			else if (tpgPlugin.Records[0].Name == "TES3")
 				intIsMaster = Convert.ToUInt32(TesPlugin.GetIsEsm(p_strPluginPath));
 
-			if (tpgPlugin.Records[0].Name == "TES4" && ((Path.GetExtension(p_strPluginPath).CompareTo(".esp") == 0) != (intIsMaster == 0)))
+			if (tpgPlugin.Records[0].Name == "TES4" && ((Path.GetExtension(p_strPluginPath).CompareTo(".esp") == 0) != ((intIsMaster == 0) && (intIsLightMaster == 0))))
 			{
-				if (intIsMaster == 0)
+				if ((intIsMaster == 0) && (intIsLightMaster == 0))
 					stbDescription.Append(@"<span style='color:#ff1100;'><b>WARNING: This plugin has the file extension .esm, but its file header marks it as an esp!</b></span><br/><br/>");
 				else
 					stbDescription.Append(@"<span style='color:#ff1100;'><b>WARNING: This plugin has the file extension .esp, but its file header marks it as an esm!</b></span><br/><br/>");
@@ -211,13 +215,17 @@ namespace Nexus.Client.Games.Gamebryo.PluginManagement
 			}
 
 			uint intIsMaster = 0;
+			uint intIsLightMaster = 0;
 			if (tpgPlugin.Records[0].Name == "TES4")
-				intIsMaster = ((Record)tpgPlugin.Records[0]).Flags1 & 1;
+			{
+			    intIsMaster = ((Record)tpgPlugin.Records[0]).Flags1 & 1;
+			    intIsLightMaster = ((Record)tpgPlugin.Records[0]).Flags1 & 512;
+			}
 			else if (tpgPlugin.Records[0].Name == "TES3")
 				intIsMaster = Convert.ToUInt32(TesPlugin.GetIsEsm(p_strPluginPath));
-			if (tpgPlugin.Records[0].Name == "TES4" && ((Path.GetExtension(p_strPluginPath).CompareTo(".esp") == 0) != (intIsMaster == 0)))
+			if (tpgPlugin.Records[0].Name == "TES4" && ((Path.GetExtension(p_strPluginPath).CompareTo(".esp") == 0) != ((intIsMaster == 0) && (intIsLightMaster == 0))))
 			{
-				if (intIsMaster == 0)
+				if ((intIsMaster == 0) && (intIsLightMaster == 0))
 					stbDescription.Append(@"<span style='color:#ff1100;'><b>WARNING: This plugin has the file extension .esm, but its file header marks it as an esp!</b></span><br/><br/>");
 				else
 					stbDescription.Append(@"<span style='color:#ff1100;'><b>WARNING: This plugin has the file extension .esp, but its file header marks it as an esm!</b></span><br/><br/>");

--- a/GamebryoBase/PluginManagement/GamebryoPluginOrderValidator.cs
+++ b/GamebryoBase/PluginManagement/GamebryoPluginOrderValidator.cs
@@ -53,11 +53,19 @@ namespace Nexus.Client.Games.Gamebryo.PluginManagement
 				if (!p_lstPlugins[i].Filename.Equals(OrderedCriticalPluginNames[i], StringComparison.OrdinalIgnoreCase))
 					return false;
 			bool booIsPreviousMaster = true;
+			bool booIsPreviousLightMaster = false;
 			foreach (GamebryoPlugin plgPlugin in p_lstPlugins)
 			{
 				if (!booIsPreviousMaster && plgPlugin.IsMaster)
 					return false;
+				// simple test esl come after esm or esl
+				if (!(booIsPreviousMaster || booIsPreviousLightMaster) && plgPlugin.IsLightMaster)
+					return false;
+				// no true esm after an esl
+				if (booIsPreviousLightMaster && plgPlugin.IsMaster && !plgPlugin.IsLightMaster)
+					return false;
 				booIsPreviousMaster = plgPlugin.IsMaster;
+				booIsPreviousLightMaster = plgPlugin.IsLightMaster;
 			}
 			for (Int32 i = p_lstPlugins.Count - 1; i >= 0; i--)
 				if (p_lstPlugins[i].HasMasters)

--- a/GamebryoBase/PluginManagement/GamebryoPluginOrderValidator.cs
+++ b/GamebryoBase/PluginManagement/GamebryoPluginOrderValidator.cs
@@ -130,6 +130,34 @@ namespace Nexus.Client.Games.Gamebryo.PluginManagement
 				}
 			}
 
+			bool booFoundLightMasters = false;
+			intFirstNonMasterIndex = p_lstPlugins.Count - 1;
+			for (Int32 i = p_lstPlugins.Count - 1; i >= 0; i--)
+			{
+				if (!booFoundLightMasters)
+					booFoundLightMasters = ((GamebryoPlugin)p_lstPlugins[i]).IsLightMaster;
+				if (!booFoundLightMasters)
+					intFirstNonMasterIndex = i - 1;
+				else
+				{
+					if ((!((GamebryoPlugin)p_lstPlugins[i]).IsLightMaster) && (!((GamebryoPlugin)p_lstPlugins[i]).IsMaster))
+					{
+						if (booHasMove)
+							((ThreadSafeObservableList<Plugin>)p_lstPlugins).Move(i, intFirstNonMasterIndex);
+						else
+						{
+							Plugin plgPlugin = p_lstPlugins[i];
+							p_lstPlugins.RemoveAt(i);
+							if (intFirstNonMasterIndex >= p_lstPlugins.Count)
+								p_lstPlugins.Add(plgPlugin);
+							else
+								p_lstPlugins.Insert(intFirstNonMasterIndex, plgPlugin);
+						}
+						intFirstNonMasterIndex--;
+					}
+				}
+			}
+
 			// Makes sure no plugin is loaded before his master.
 			for (Int32 i = p_lstPlugins.Count - 1; i >= 0; i--)
 			{

--- a/GamebryoBase/PluginManagement/LoadOrderManager/PluginOrderManager.cs
+++ b/GamebryoBase/PluginManagement/LoadOrderManager/PluginOrderManager.cs
@@ -23,7 +23,7 @@ namespace Nexus.Client.Games.Gamebryo.PluginManagement.LoadOrder
 	{
 		private static readonly object m_objLock = new object();
 		private static Dictionary<string, string> dctFileHashes = new Dictionary<string, string>();
-		private Regex m_rgxPluginFile = new Regex(@"(?i)^.+\.es[mp]$");
+		private Regex m_rgxPluginFile = new Regex(@"(?i)^.+\.es[mpl]$");
 		private List<string> m_lstActivePlugins = new List<string>();
 		private DateTime m_dtiMasterDate = DateTime.Now;
 		private ThreadSafeObservableList<WriteLoadOrderTask> TaskList = new ThreadSafeObservableList<WriteLoadOrderTask>();
@@ -400,6 +400,18 @@ namespace Nexus.Client.Games.Gamebryo.PluginManagement.LoadOrder
 			FileWatcher.Filter = "*.esp";
 			if (TimestampOrder)
 				FileWatcher.Changed += new FileSystemEventHandler(FileWatcherOnChangedLoose);
+			FileWatcher.Deleted += new FileSystemEventHandler(FileWatcherOnDeletedLoose);
+			FileWatcher.Created += new FileSystemEventHandler(FileWatcherOnCreatedLoose);
+			FileWatcher.EnableRaisingEvents = true;
+			FileWatchers.Add(FileWatcher);
+
+			FileWatcher = new FileSystemWatcher();
+			FileWatcher.Path = GameMode.PluginDirectory;
+			FileWatcher.IncludeSubdirectories = false;
+			FileWatcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.Size | NotifyFilters.CreationTime;
+			FileWatcher.Filter = "*.esl";
+			if (TimestampOrder)
+			    FileWatcher.Changed += new FileSystemEventHandler(FileWatcherOnChangedLoose);
 			FileWatcher.Deleted += new FileSystemEventHandler(FileWatcherOnDeletedLoose);
 			FileWatcher.Created += new FileSystemEventHandler(FileWatcherOnCreatedLoose);
 			FileWatcher.EnableRaisingEvents = true;
@@ -907,7 +919,7 @@ namespace Nexus.Client.Games.Gamebryo.PluginManagement.LoadOrder
 					lstOrderedPlugins = diPluginFolder
 										.EnumerateFiles()
 										.OrderBy(file => file.LastWriteTime)
-										.Where(file => file.Extension.Equals(".esp", StringComparison.InvariantCultureIgnoreCase) || file.Extension.Equals(".esm", StringComparison.InvariantCultureIgnoreCase))
+										.Where(file => file.Extension.Equals(".esp", StringComparison.InvariantCultureIgnoreCase) || file.Extension.Equals(".esl", StringComparison.InvariantCultureIgnoreCase) || file.Extension.Equals(".esm", StringComparison.InvariantCultureIgnoreCase))
 										.Select(file => file.FullName)
 										.ToList();
 				}
@@ -1057,7 +1069,7 @@ namespace Nexus.Client.Games.Gamebryo.PluginManagement.LoadOrder
 					lstLoosePlugins = diPluginFolder
 										.EnumerateFiles()
 										.OrderBy(file => file.LastWriteTime)
-										.Where(file => file.Extension.Equals(".esp", StringComparison.InvariantCultureIgnoreCase) || file.Extension.Equals(".esm", StringComparison.InvariantCultureIgnoreCase))
+										.Where(file => file.Extension.Equals(".esp", StringComparison.InvariantCultureIgnoreCase) || file.Extension.Equals(".esl", StringComparison.InvariantCultureIgnoreCase) || file.Extension.Equals(".esm", StringComparison.InvariantCultureIgnoreCase))
 										.Select(file => file.FullName)
 										.ToList();
 

--- a/GamebryoBase/Plugins/GamebryoPlugin.cs
+++ b/GamebryoBase/Plugins/GamebryoPlugin.cs
@@ -16,6 +16,12 @@ namespace Nexus.Client.Games.Gamebryo.Plugins
 		/// <value>Whether the plugin is a master file.</value>
 		public bool IsMaster { get; private set; }
 
+		/// <summary>
+		/// Gets whether the plugin is a light master file.
+		/// </summary>
+		/// <value>Whether the plugin is a light master file.</value>
+		public bool IsLightMaster { get; private set; }
+
 		#endregion
 
 		#region Constructors
@@ -27,10 +33,12 @@ namespace Nexus.Client.Games.Gamebryo.Plugins
 		/// <param name="p_strDescription">The description of the plugin.</param>
 		/// <param name="p_imgPicture">The picture of the plugin.</param>
 		/// <param name="p_booIsMaster">Whether the plugin is a master file.</param>
-		public GamebryoPlugin(string p_strPath, string p_strDescription, Image p_imgPicture, bool p_booIsMaster)
+		/// <param name="p_booIsLightMaster">Whether the plugin is a light master file.</param>
+		public GamebryoPlugin(string p_strPath, string p_strDescription, Image p_imgPicture, bool p_booIsMaster, bool p_booIsLightMaster)
 			: base(p_strPath, p_strDescription, p_imgPicture)
 		{
 			IsMaster = p_booIsMaster;
+			IsLightMaster = p_booIsLightMaster;
 		}
 
 		#endregion

--- a/NexusClient/ModManagement/VirtualModActivator/VirtualModActivator.cs
+++ b/NexusClient/ModManagement/VirtualModActivator/VirtualModActivator.cs
@@ -1915,7 +1915,7 @@ namespace Nexus.Client.ModManagement
 				{
 					if (GameMode.UsesPlugins)
 					{
-						List<IVirtualModLink> ivlLinks = lstVirtualLinks.Where(x => x.ModInfo.ModFileName.ToLowerInvariant() == Path.GetFileName(modMod.Filename).ToLowerInvariant() && (Path.GetExtension(x.VirtualModPath).ToLowerInvariant() == ".esp" || Path.GetExtension(x.VirtualModPath).ToLowerInvariant() == ".esm")).ToList();
+						List<IVirtualModLink> ivlLinks = lstVirtualLinks.Where(x => x.ModInfo.ModFileName.ToLowerInvariant() == Path.GetFileName(modMod.Filename).ToLowerInvariant() && (Path.GetExtension(x.VirtualModPath).ToLowerInvariant() == ".esp" || Path.GetExtension(x.VirtualModPath).ToLowerInvariant() == ".esl" || Path.GetExtension(x.VirtualModPath).ToLowerInvariant() == ".esm")).ToList();
 						if (ivlLinks != null)
 						{
 							foreach (IVirtualModLink Link in ivlLinks)


### PR DESCRIPTION
I believe I've gotten most if not all the basics needed for ESL support to work for FO4 and Skyrim SE. I've only been able to test locally with FO4 since I don't own any Skyrim SE creation content.

Something to note about the ESLs that I found. Bethesda's files have both the ESL and ESM flags set. Content created via CK and converted to ESL only have the ESL flag.

Only one notable concern I have relates to changes I made in GamebryoPluginOrderValidator.cs. I'm not familiar enough with C# or the code base to know if there's a better way to handle the sorting. I left the original bubble sort style algorithm for the masters, then added another one for the light masters.  There may be an edge case where Bethesda ESL files may not get sorted above 3rd party ESLs. Though in my testing it seems the sorting called called multiple times and it resolved itself before the user could see it incorrect.