### PR TITLE
BUGFIX #181 - UI is unresponsive

### DIFF
--- a/FOMod/FOMod.cs
+++ b/FOMod/FOMod.cs
@@ -43,6 +43,7 @@ namespace Nexus.Client.Mods.Formats.FOMod
 
 		private string m_strModId = null;
 		private string m_strDownloadId = null;
+        private DateTime? m_dtDownloadDate = null;
 		private string m_strModName = null;
 		private string m_strFileName = null;
 		private string m_strHumanReadableVersion = null;
@@ -105,11 +106,27 @@ namespace Nexus.Client.Mods.Formats.FOMod
 			}
 		}
 
-		/// <summary>
-		/// Gets or sets the filename of the mod.
-		/// </summary>
-		/// <value>The filename of the mod.</value>
-		public string FileName
+        /// <summary>
+        /// Gets or sets the Download date of the mod.
+        /// </summary>
+        /// <remarks>The Download date of the mod</remarks>
+        public DateTime? DownloadDate
+        {
+            get
+            {
+                return m_dtDownloadDate;
+            }
+            set
+            {
+                SetPropertyIfChanged(ref m_dtDownloadDate, value, () => DownloadDate);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the filename of the mod.
+        /// </summary>
+        /// <value>The filename of the mod.</value>
+        public string FileName
 		{
 			get
 			{
@@ -502,7 +519,9 @@ namespace Nexus.Client.Mods.Formats.FOMod
 			m_strFilePath = p_strFilePath;
 			m_arcFile = new Archive(p_strFilePath);
 
-			p_mcmModCacheManager.MigrateCacheFile(this);
+            m_dtDownloadDate = File.GetLastWriteTime(m_strFilePath);
+
+            p_mcmModCacheManager.MigrateCacheFile(this);
 
 			#region Check for cacheInfo.txt file
 

--- a/ModManager.Interface/Mods/IModInfo.cs
+++ b/ModManager.Interface/Mods/IModInfo.cs
@@ -23,11 +23,17 @@ namespace Nexus.Client.Mods
 		/// <remarks>The DownloadId of the mod</remarks>
 		string DownloadId { get; set; }
 
-		/// <summary>
-		/// Gets or sets the name of the mod.
-		/// </summary>
-		/// <value>The name of the mod.</value>
-		string ModName { get; }
+        /// <summary>
+        /// Gets or sets the Download date of the mod.
+        /// </summary>
+        /// <remarks>The Download date of the mod</remarks>
+        DateTime? DownloadDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the mod.
+        /// </summary>
+        /// <value>The name of the mod.</value>
+        string ModName { get; }
 
 		/// <summary>
 		/// Gets or sets the Filename of the mod.

--- a/NexusClient/ModAuthoring/Project.cs
+++ b/NexusClient/ModAuthoring/Project.cs
@@ -18,7 +18,8 @@ namespace Nexus.Client.ModAuthoring
 	{
 		private string m_strModId = null;
 		private string m_strDownloadId = null;
-		private string m_strModName = null;
+        private DateTime? m_dtDownloadDate = null;
+        private string m_strModName = null;
 		private string m_strFileName = null;
 		private string m_strHumanReadableVersion = null;
 		private string m_strLastKnownVersion = null;
@@ -75,11 +76,27 @@ namespace Nexus.Client.ModAuthoring
 			}
 		}
 
-		/// <summary>
-		/// Gets or sets the filename of the mod.
-		/// </summary>
-		/// <value>The filename of the mod.</value>
-		public string FileName
+        /// <summary>
+        /// Gets or sets the Download date of the mod.
+        /// </summary>
+        /// <remarks>The Download date of the mod</remarks>
+        public DateTime? DownloadDate
+        {
+            get
+            {
+                return m_dtDownloadDate;
+            }
+            set
+            {
+                SetPropertyIfChanged(ref m_dtDownloadDate, value, () => DownloadDate);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the filename of the mod.
+        /// </summary>
+        /// <value>The filename of the mod.</value>
+        public string FileName
 		{
 			get
 			{

--- a/NexusClient/ModManagement/InstallationLog/InstallLog.DummyMod.cs
+++ b/NexusClient/ModManagement/InstallationLog/InstallLog.DummyMod.cs
@@ -209,11 +209,17 @@ namespace Nexus.Client.ModManagement.InstallationLog
 			/// <remarks>The DownloadId of the mod</remarks>
 			public string DownloadId { get; set; }
 
-			/// <summary>
-			/// Gets or sets the name of the mod.
-			/// </summary>
-			/// <value>The name of the mod.</value>
-			public string ModName { get; set; }
+            /// <summary>
+            /// Gets or sets the Download date of the mod.
+            /// </summary>
+            /// <remarks>The Download date of the mod</remarks>
+            public DateTime? DownloadDate { get; set; }
+
+            /// <summary>
+            /// Gets or sets the name of the mod.
+            /// </summary>
+            /// <value>The name of the mod.</value>
+            public string ModName { get; set; }
 
 			/// <summary>
 			/// Gets or sets the filename of the mod.

--- a/NexusClient/ModRepositories/ModInfo.cs
+++ b/NexusClient/ModRepositories/ModInfo.cs
@@ -25,11 +25,17 @@ namespace Nexus.Client.ModRepositories
 		/// <remarks>The DownloadId of the mod.</remarks>
 		public string DownloadId { get; set; }
 
-		/// <summary>
-		/// Gets or sets the name of the mod.
-		/// </summary>
-		/// <value>The name of the mod.</value>
-		public string ModName { get; set; }
+        /// <summary>
+        /// Gets or sets the Download date of the mod.
+        /// </summary>
+        /// <remarks>The Download date of the mod</remarks>
+        public DateTime? DownloadDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the mod.
+        /// </summary>
+        /// <value>The name of the mod.</value>
+        public string ModName { get; set; }
 
 		/// <summary>
 		/// Gets or sets the filename of the mod.

--- a/NexusClient/UI/Controls/CategoryListView.cs
+++ b/NexusClient/UI/Controls/CategoryListView.cs
@@ -446,18 +446,9 @@ namespace Nexus.Client.UI.Controls
 				string Val = String.Empty;
 
 				if (rowObject.GetType() != typeof(ModCategory))
-				{
-					string strFilePath = ((IMod)rowObject).Filename;
-					if (!String.IsNullOrWhiteSpace(strFilePath))
-						if (File.Exists(strFilePath))
-							Val = File.GetLastWriteTime(((IMod)rowObject).Filename).ToString();
-					if (CheckDate(Val))
-						return Convert.ToDateTime(Val);
-				}
-				else
+					return ((IMod)rowObject).DownloadDate;
+                else
 					return ((ModCategory)rowObject).NewMods.ToString();
-
-				return null;
 			};
 
 			tlcDownloadDate.AspectToStringConverter = delegate(object x)

--- a/OMod/OMod.cs
+++ b/OMod/OMod.cs
@@ -46,7 +46,8 @@ namespace Nexus.Client.Mods.Formats.OMod
 
 		private string m_strModId = null;
 		private string m_strDownloadId = null;
-		private string m_strModName = null;
+        private DateTime? m_dtDownloadDate = null;
+        private string m_strModName = null;
 		private string m_strFileName = null;
 		private string m_strHumanReadableVersion = null;
 		private string m_strLastKnownVersion = null;
@@ -108,11 +109,27 @@ namespace Nexus.Client.Mods.Formats.OMod
 			}
 		}
 
-		/// <summary>
-		/// Gets or sets the name of the mod.
-		/// </summary>
-		/// <value>The name of the mod.</value>
-		public string ModName
+        /// <summary>
+        /// Gets or sets the Download date of the mod.
+        /// </summary>
+        /// <remarks>The Download date of the mod</remarks>
+        public DateTime? DownloadDate
+        {
+            get
+            {
+                return m_dtDownloadDate;
+            }
+            set
+            {
+                SetPropertyIfChanged(ref m_dtDownloadDate, value, () => DownloadDate);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the mod.
+        /// </summary>
+        /// <value>The name of the mod.</value>
+        public string ModName
 		{
 			get
 			{
@@ -518,7 +535,8 @@ namespace Nexus.Client.Mods.Formats.OMod
 		{
 			Format = p_mftModFormat;
 			m_strFilePath = p_strFilePath;
-			m_arcFile = new Archive(p_strFilePath);
+            m_dtDownloadDate = File.GetLastWriteTime(m_strFilePath);
+            m_arcFile = new Archive(p_strFilePath);
 			ModName = Path.GetFileNameWithoutExtension(Filename);
 			bool p_booUseCache = true;
 


### PR DESCRIPTION
BUGFIX #181 : Fixed UI unresponsiveness due to the Download date column being populated by checking the modification date of the mod archive. The date is read when the ModInfo entry is created (OMod or FOMod constructor).