### PR TITLE
BUGFIX #183 - Fixed directories being incorrectly trimmed

### DIFF
--- a/ModManager.Interface/Games/SteamInstallationPathDetector.cs
+++ b/ModManager.Interface/Games/SteamInstallationPathDetector.cs
@@ -84,9 +84,9 @@ namespace Nexus.Client.Games
                 {
                     Trace.TraceInformation("Getting install folder from Uninstall.");
 
-                    var uniPath = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Steam App " + steamId, "InstallLocation", null).ToString();
+                    var uniPath = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Steam App " + steamId, "InstallLocation", null)?.ToString();
 
-                    if (Directory.Exists(uniPath))
+                    if (uniPath != null && Directory.Exists(uniPath))
                         strValue = uniPath;
                 }
             }

--- a/NexusClient/ModManagement/CategoriesUpdateCheckTask.cs
+++ b/NexusClient/ModManagement/CategoriesUpdateCheckTask.cs
@@ -103,7 +103,7 @@ namespace Nexus.Client.ModManagement
 			List<IMod> ModCheck = new List<IMod>();
 			ConfirmActionMethod camConfirm = (ConfirmActionMethod)p_objArgs[0];
 
-			string ModInstallDirectory = CurrentGameModeModDirectory.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).Trim(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar; 
+			string ModInstallDirectory = CurrentGameModeModDirectory.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar; 
 
 			OverallMessage = "Updating categories info: setup search..";
 			OverallProgress = 0;

--- a/NexusClient/ModManagement/CategoryManager/CategoryManager.cs
+++ b/NexusClient/ModManagement/CategoryManager/CategoryManager.cs
@@ -150,7 +150,7 @@ namespace Nexus.Client.ModManagement
 		/// <param name="p_strCategoryPath">The path from which to load the categories.</param>
 		public CategoryManager(string p_strModInstallDirectory, string p_strCategoryPath)
 		{
-			ModInstallDirectory = p_strModInstallDirectory.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).Trim(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+			ModInstallDirectory = p_strModInstallDirectory.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
 			CategoryPath = Path.Combine(ModInstallDirectory, p_strCategoryPath);
 			CategoryFilePath = Path.Combine(CategoryPath, CATEGORY_FILE);
 		}

--- a/NexusClient/ModManagement/InstallationLog/InstallLog.cs
+++ b/NexusClient/ModManagement/InstallationLog/InstallLog.cs
@@ -229,7 +229,7 @@ namespace Nexus.Client.ModManagement.InstallationLog
 			m_dicInstalledFiles = new InstalledItemDictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 			m_dicInstalledIniEdits = new InstalledItemDictionary<IniEdit, string>();
 			m_dicInstalledGameSpecificValueEdits = new InstalledItemDictionary<string, byte[]>();
-			ModInstallDirectory = p_strModInstallDirectory.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).Trim(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+			ModInstallDirectory = p_strModInstallDirectory.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
 			ManagedModRegistry = p_mdrManagedModRegistry;
 			LogPath = p_strLogPath;
 			GameMode = p_gmdGameMode;

--- a/NexusClient/ModManagement/InstallationLog/Upgraders/Upgrade0200Task.cs
+++ b/NexusClient/ModManagement/InstallationLog/Upgraders/Upgrade0200Task.cs
@@ -24,7 +24,7 @@ namespace Nexus.Client.ModManagement.InstallationLog.Upgraders
 		{
 			if (!File.Exists(p_strLogPath))
 				return;
-			string strModInstallDirectory = p_strModInstallDirectory.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).Trim(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+			string strModInstallDirectory = p_strModInstallDirectory.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
 			XDocument docLog = XDocument.Load(p_strLogPath);
 
 			string strLogVersion = docLog.Element("installLog").Attribute("fileVersion").Value;

--- a/NexusClient/ModManagement/InstallationLog/Upgraders/Upgrade0300Task.cs
+++ b/NexusClient/ModManagement/InstallationLog/Upgraders/Upgrade0300Task.cs
@@ -24,7 +24,7 @@ namespace Nexus.Client.ModManagement.InstallationLog.Upgraders
 		{
 			if (!File.Exists(p_strLogPath))
 				return;
-			string strModInstallDirectory = p_strModInstallDirectory.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).Trim(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+			string strModInstallDirectory = p_strModInstallDirectory.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
 			XDocument docLog = XDocument.Load(p_strLogPath);
 
 			string strLogVersion = docLog.Element("installLog").Attribute("fileVersion").Value;

--- a/NexusClient/ModManagement/InstallationLog/Upgraders/Upgrade0400Task.cs
+++ b/NexusClient/ModManagement/InstallationLog/Upgraders/Upgrade0400Task.cs
@@ -24,7 +24,7 @@ namespace Nexus.Client.ModManagement.InstallationLog.Upgraders
 		{
 			if (!File.Exists(p_strLogPath))
 				return;
-			string strModInstallDirectory = p_strModInstallDirectory.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).Trim(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+			string strModInstallDirectory = p_strModInstallDirectory.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
 			XDocument docLog = XDocument.Load(p_strLogPath);
 
 			string strLogVersion = docLog.Element("installLog").Attribute("fileVersion").Value;

--- a/NexusClient/ModManagement/ModRegistry.cs
+++ b/NexusClient/ModManagement/ModRegistry.cs
@@ -35,7 +35,7 @@ namespace Nexus.Client.ModManagement
 
 			List<string> lstExludedPaths = new List<string>();
 			for (Int32 i = 0; i < p_strExcludedSubDirectories.Length; i++)
-				lstExludedPaths.Add((p_strExcludedSubDirectories[i].Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).Trim(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar).ToLower());
+				lstExludedPaths.Add((p_strExcludedSubDirectories[i].Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar).ToLower());
 
 			ModRegistry mdrRegistry = new ModRegistry(p_frgFormatRegistry, p_gmdGameMode);
 			string[] strMods = Directory.GetFiles(p_strSearchPath, "*", p_booRecurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);

--- a/Witcher3/Witcher3GameModeFactory.cs
+++ b/Witcher3/Witcher3GameModeFactory.cs
@@ -71,9 +71,9 @@ namespace Nexus.Client.Games.Witcher3
 				{
 					Trace.TraceInformation("Getting GOG install folder.");
 
-					var gogPath = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\GOG.com\Games\1207664643", "PATH", null).ToString();
+					var gogPath = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\GOG.com\Games\1207664643", "PATH", null)?.ToString();
 
-					if (Directory.Exists(gogPath))
+					if (gogPath != null && Directory.Exists(gogPath))
 						strValue = gogPath;
 				}
 			}


### PR DESCRIPTION
BUGFIX #183 : Fixed directories being incorrectly trimmed when using UNC paths (e.g. \\RemoteServer\Mods)
Avoid throwing null reference exceptions when reading values from the registry