### PR TITLE
FEATURE: User is able to download the latest version of the selected mod from NMM client

### DIFF
--- a/NexusClient.Interface/ProgrammeMetadata.cs
+++ b/NexusClient.Interface/ProgrammeMetadata.cs
@@ -24,7 +24,7 @@ namespace Nexus.Client
 		/// (c) should change when there is a minor alteration to the programme.
 		/// Something akin to a minor bug fix, or a typo correction.
 		/// </remarks>
-		public const string VersionString = "0.63.17";
+		public const string VersionString = "0.63.18";
 
 		/// <summary>
 		/// Gets the full name of the mod manager.

--- a/NexusClient/ModManagement/UI/ModManagerControl.cs
+++ b/NexusClient/ModManagement/UI/ModManagerControl.cs
@@ -131,6 +131,7 @@ namespace Nexus.Client.ModManagement.UI
 			clwCategoryView.ModReadmeFileRequested += CategoryListView_OpenReadMeFile;
 			clwCategoryView.CellEditFinishing += new BrightIdeasSoftware.CellEditEventHandler(CategoryListView_CellEditFinishing);
 			clwCategoryView.CellToolTipShowing += new EventHandler<BrightIdeasSoftware.ToolTipShowingEventArgs>(CategoryListView_CellToolTipShowing);
+            clwCategoryView.GetNewModVersion += new EventHandler<ModGetNewVersionEventArgs>(CategoryListView_GetNewModVersion);
 
 			tsbAddMod.DefaultItem = tsbAddMod.DropDownItems[0];
 			tsbAddMod.Text = tsbAddMod.DefaultItem.Text;
@@ -1107,6 +1108,15 @@ namespace Nexus.Client.ModManagement.UI
 				clwCategoryView.ReloadList(true);
 			}
 		}
+
+        private void CategoryListView_GetNewModVersion(object sender, EventArgs e)
+        {
+            if(e is ModGetNewVersionEventArgs)
+            {
+                var args = e as ModGetNewVersionEventArgs;
+                ViewModel.AddModCommand.Execute(args.DownloadLink);
+            }
+        }
 
 		/// <summary>
 		/// Handles the <see cref="CategoryListView.AllUpdateWarningsToggled"/> of the toggle

--- a/NexusClient/NexusClient.csproj
+++ b/NexusClient/NexusClient.csproj
@@ -324,6 +324,7 @@
     <Compile Include="UI\Controls\BackedProfilesListView.designer.cs" />
     <Compile Include="UI\Controls\ModEventArgs.cs" />
     <Compile Include="UI\Controls\ModActionEventArgs.cs" />
+    <Compile Include="UI\Controls\ModGetNewVersionEventArgs.cs" />
     <Compile Include="UI\Controls\ModReadmeRequestEventArgs.cs" />
     <Compile Include="UI\Controls\ModInfoRequestEventArgs.cs" />
     <Compile Include="UI\Controls\ProfileModsListView.cs">

--- a/NexusClient/UI/Controls/CategoryListView.cs
+++ b/NexusClient/UI/Controls/CategoryListView.cs
@@ -64,6 +64,11 @@ namespace Nexus.Client.UI.Controls
 		/// </summary>
 		public event EventHandler<ModUpdateWarningEventArgs> UpdateWarningToggled;
 
+        /// <summary>
+        /// Occurs whenever a new mod version for a selected mod is selected.
+        /// </summary>
+        public event EventHandler<ModGetNewVersionEventArgs> GetNewModVersion;
+
 		#endregion
 
 		#region Properties
@@ -1359,7 +1364,8 @@ namespace Nexus.Client.UI.Controls
 		/// <param name="e">A <see cref="System.EventArgs"/> describing the event arguments.</param>
         private void cmsContextMenu_GetNewVersion(object sender, EventArgs e)
         {
-            throw new NotImplementedException();
+            var eventArgs = new ModGetNewVersionEventArgs(SelectedMod, Settings.RememberedGameMode);
+            this.GetNewModVersion?.Invoke(sender, eventArgs);
         }
 
         /// <summary>

--- a/NexusClient/UI/Controls/CategoryListView.cs
+++ b/NexusClient/UI/Controls/CategoryListView.cs
@@ -30,14 +30,15 @@ namespace Nexus.Client.UI.Controls
 		private ToolStripMenuItem m_mniModUninstall;
 		private ToolStripMenuItem m_mniModReadme;
 		private ToolStripMenuItem m_mniModWarnings;
+        private ToolStripMenuItem m_mniModGetNewVersion;
 
 
-		#region Custom Events
+        #region Custom Events
 
-		/// <summary>
-		/// Occurs whenever all mods "warning update" status toggled.
-		/// </summary>
-		public event EventHandler<ModUpdateWarningEventArgs> AllUpdateWarningsToggled;
+        /// <summary>
+        /// Occurs whenever all mods "warning update" status toggled.
+        /// </summary>
+        public event EventHandler<ModUpdateWarningEventArgs> AllUpdateWarningsToggled;
 		public event EventHandler CategorySwitch;
 		public event EventHandler CategoryRemoved;
 		/// <summary>
@@ -1176,6 +1177,8 @@ namespace Nexus.Client.UI.Controls
 			m_mniModReinstall = new ToolStripMenuItem("Reinstall Mod", new Bitmap(Properties.Resources.change_game_mode, 16, 16),
 				(s, e) => this.OnModActionRequested(ModAction.Reinstall));
 			m_mniModReadme = new ToolStripMenuItem("Open readme", new Bitmap(Properties.Resources.text_x_generic, 16, 16));
+
+            m_mniModGetNewVersion = new ToolStripMenuItem("Download new version", new Bitmap(Properties.Resources.down, 16, 16));
 		}
 
 		/// <summary>
@@ -1229,8 +1232,21 @@ namespace Nexus.Client.UI.Controls
 				{
 					cmsContextMenu.Items.Add(m_mniModUninstall);
 				}
-			}
-			else
+
+                //if mod has a newer version - enable retrieval of a new verion, else - disable
+                if(!this.SelectedMod.IsMatchingVersion())
+                {
+                    m_mniModGetNewVersion.Enabled = true;
+                }
+                else
+                {
+                    m_mniModGetNewVersion.Enabled = false;
+                }
+                m_mniModGetNewVersion.Click += cmsContextMenu_GetNewVersion;
+                cmsContextMenu.Items.Add(m_mniModGetNewVersion);
+
+            }
+            else
 			{
 				// multi-mod management
 				// can:
@@ -1334,12 +1350,24 @@ namespace Nexus.Client.UI.Controls
 			this.OnModReadmeFileRequested(new ModReadmeRequestEventArgs(this.SelectedMod, fileName));
 		}
 
-		/// <summary>
-		/// Handles the cmsContextMenu.CategoryClicked event.
+
+        /// <summary>
+		/// Handles the cmsContextMenu.OpenReadMefile event.
+        /// Starts a download of a newer version of the selected mod.
 		/// </summary>
 		/// <param name="sender">The object that raised the event.</param>
 		/// <param name="e">A <see cref="System.EventArgs"/> describing the event arguments.</param>
-		private void cmsContextMenu_CategoryClicked(object sender, EventArgs e)
+        private void cmsContextMenu_GetNewVersion(object sender, EventArgs e)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Handles the cmsContextMenu.CategoryClicked event.
+        /// </summary>
+        /// <param name="sender">The object that raised the event.</param>
+        /// <param name="e">A <see cref="System.EventArgs"/> describing the event arguments.</param>
+        private void cmsContextMenu_CategoryClicked(object sender, EventArgs e)
 		{
 			ToolStripItem item = sender as ToolStripItem;
 

--- a/NexusClient/UI/Controls/ModGetNewVersionEventArgs.cs
+++ b/NexusClient/UI/Controls/ModGetNewVersionEventArgs.cs
@@ -1,0 +1,28 @@
+﻿using Nexus.Client.Mods;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nexus.Client.UI.Controls
+{
+    public class ModGetNewVersionEventArgs : ModEventArgs
+    {
+        /// <summary>
+        /// Get a download link of the newest game mod file.
+        /// </summary>
+        public string DownloadLink { get; private set; }
+
+        /// <summary>
+        /// Generates a download link for the latest version of the selected mod.
+        /// </summary>
+        /// <param name="p_modMod">Mod to be updated.</param>
+        /// <param name="gameMode">Currently active Game Mode.</param>
+        public ModGetNewVersionEventArgs(IMod p_modMod,string gameMode)
+            : base(p_modMod)
+        {
+            DownloadLink = $"nxm://{gameMode}/mods/{p_modMod.Id}/files/{p_modMod.DownloadId}";
+        }
+    }
+}

--- a/NexusClient/data/releasenotes.rtf
+++ b/NexusClient/data/releasenotes.rtf
@@ -1,7 +1,17 @@
 {\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang2057\deflangfe1041{\fonttbl{\f0\fswiss\fprq2\fcharset0 Verdana;}{\f1\fswiss\fprq2\fcharset0 Calibri;}{\f2\fnil\fcharset2 Symbol;}}
 {\colortbl ;\red0\green0\blue255;\red0\green0\blue0;\red255\green0\blue0;}
-{\*\generator Riched20 10.0.15063}{\*\mmathPr\mdispDef1\mwrapIndent1440 }\viewkind4\uc1 
-\pard\widctlpar\qj\b\f0\fs16 Version 0.63.17\par
+{\*\generator Riched20 10.0.16299}{\*\mmathPr\mdispDef1\mwrapIndent1440 }\viewkind4\uc1 
+\pard\widctlpar\qj\b\f0\fs16\par
+Version 0.63.18\par
+\par
+
+\pard 
+{\pntext\f0 1.\tab}{\*\pn\pnlvlbody\pnf0\pnindent0\pnstart1\pndec{\pntxta.}}
+\fi-360\li720\qj\cf1 New Feature:\cf2\b0  User is able to initiate the download of the latest mod version from NMM client.\par
+
+\pard\widctlpar\qj\cf0\b\par
+\par
+Version 0.63.17\par
 \par
 
 \pard 

--- a/Setup/setup.iss
+++ b/Setup/setup.iss
@@ -8,7 +8,7 @@
 
 #define MyAppSetupName 'Nexus Mod Manager'
 #define MyExeName 'NexusClient.exe'
-#define MyAppVersion '0.63.17'
+#define MyAppVersion '0.63.18'
 #define SetupScriptVersion '0.7.1.0'
 #define MyPublisher 'Black Tree Gaming'
 [Setup]


### PR DESCRIPTION
Steps to reproduce:
1) Select an outdated mod
2) Open context menu of the mod (right click on the selected mod)
3) Select "Download new version"

![image](https://user-images.githubusercontent.com/5007741/34462692-dcc18b64-ee49-11e7-95ff-bc48ca0b2a67.png)

Implemented feature:
- adds a latest mod version to download.
- does not initiate upgrading of a mod automatically. This has to be done by user himself (to avoid breaking game saves/setup/files).
- get the latest specified version. Cannot distinguish between multiple variations of the same version.