### PR TITLE
Large file (2gb+) support for mods

### DIFF
--- a/ChinhDo.Transactions.FileManager/TxEnlistment.cs
+++ b/ChinhDo.Transactions.FileManager/TxEnlistment.cs
@@ -266,6 +266,35 @@ namespace ChinhDo.Transactions
 				}
 			}
 
+            /// <summary>
+			/// Creates a file, and writes the specified <paramref name="stream"/> to the file. 
+            /// If the file already exists, it is overwritten.
+			/// </summary>
+			/// <param name="path">The file to write to.</param>
+			/// <param name="stream">The stream to write to the file, which is disposed after the write.</param>
+            public void WriteFileStream(string path, FileStream stream)
+            {
+                var r = new RollbackFile(path);
+                try
+                {
+                    using (var file = File.Create(path))
+                    {
+                        stream.CopyTo(file);
+                        stream.Dispose();
+                    }
+                }
+                catch (Exception e)
+                {
+                    r.CleanUp();
+                    throw new Exception(e.Message, e);
+                }
+                if (_tx != null)
+                {
+                    _journal.Add(r);
+                    Enlist();
+                }
+            }
+
 			#endregion
 
 			#region IEnlistmentNotification Members

--- a/ChinhDo.Transactions.FileManager/TxFileManager.cs
+++ b/ChinhDo.Transactions.FileManager/TxFileManager.cs
@@ -124,6 +124,17 @@ namespace ChinhDo.Transactions
 			GetEnlistment().WriteAllBytes(path, contents);
 		}
 
+        /// <summary>
+        /// Creates a file, and writes the specified <paramref name="stream"/> to the file. 
+        /// If the file already exists, it is overwritten.
+        /// </summary>
+        /// <param name="path">The file to write to.</param>
+        /// <param name="stream">The stream to write to the file, which is disposed after the write.</param>
+        public void WriteFileStream(string path, FileStream stream)
+        {
+            GetEnlistment().WriteFileStream(path, stream);
+        }
+
         #endregion
 
         /// <summary>

--- a/FOMod/FOMod.cs
+++ b/FOMod/FOMod.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -8,7 +7,6 @@ using System.Text.RegularExpressions;
 using System.Xml;
 using Nexus.Client.ModManagement.Scripting;
 using Nexus.Client.Util;
-using SevenZip;
 using System.Text;
 
 namespace Nexus.Client.Mods.Formats.FOMod

--- a/FOMod/FOMod.cs
+++ b/FOMod/FOMod.cs
@@ -67,6 +67,8 @@ namespace Nexus.Client.Mods.Formats.FOMod
 		private bool m_booAllowArchiveEdits = false;
 		private bool m_booNestedArchives = false;
 
+        private IEnvironmentInfo m_eifEnvironmentInfo;
+
 		protected List<string> IgnoreFolders = new List<string> { "__MACOSX" };
 
 		#endregion
@@ -513,6 +515,7 @@ namespace Nexus.Client.Mods.Formats.FOMod
 		/// <param name="p_stgScriptTypeRegistry">The registry of supported script types.</param>
 		public FOMod(string p_strFilePath, FOModFormat p_mftModFormat, IEnumerable<string> p_enmStopFolders, string p_strPluginsDirectoryName, IEnumerable<string> p_enmPluginExtensions, IModCacheManager p_mcmModCacheManager, IScriptTypeRegistry p_stgScriptTypeRegistry, bool p_booUsePlugins, bool p_booNestedArchives)
 		{
+            m_eifEnvironmentInfo = p_mcmModCacheManager.EnvironmentInfo;
 			StopFolders = new List<string>(p_enmStopFolders);
 			if (!StopFolders.Contains("fomod", StringComparer.OrdinalIgnoreCase))
 				StopFolders.Add("fomod");
@@ -1070,6 +1073,23 @@ namespace Nexus.Client.Mods.Formats.FOMod
 				return File.ReadAllBytes(Path.Combine(m_strCachePath, GetRealPath(p_strFile)));		
 			return m_arcFile.GetFileContents(GetRealPath(p_strFile));
 		}
+
+        /// <summary>
+        /// Retrieves FileStream to the specified file from the fomod.
+        /// </summary>
+        /// <param name="p_strFile">The file which stream to retrieve.</param>
+        /// <returns>The requested file data.</returns>
+        public FileStream GetFileStream(string p_strFile)
+        {
+            // File is present in cache
+            if ((Directory.Exists(m_strCachePath) && (File.Exists(Path.Combine(m_strCachePath, GetRealPath(p_strFile))))))
+            {
+                return new FileStream(p_strFile, FileMode.Open);
+            }
+            
+            // Otherwise grab file from archive.
+            return m_arcFile.GetFileStream(GetRealPath(p_strFile), m_eifEnvironmentInfo.TemporaryPath);
+        }
 
 		/// <summary>
 		/// Retrieves the list of files in this FOMod.

--- a/ModManager.Interface/Mods/IMod.cs
+++ b/ModManager.Interface/Mods/IMod.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
+﻿using System.Collections.Generic;
+using System.IO;
 using Nexus.Client.Util;
 
 namespace Nexus.Client.Mods
@@ -81,6 +80,13 @@ namespace Nexus.Client.Mods
 		/// <exception cref="System.IO.FileNotFoundException">Thrown if the specified file
 		/// is not in the mod.</exception>
 		byte[] GetFile(string p_strFile);
+
+        /// <summary>
+        /// Retrieves stream for the specified file from the mod.
+        /// </summary>
+        /// <param name="p_strFile">The file to retrieve</param>
+        /// <returns>Stream of the requested file data.</returns>
+        FileStream GetFileStream(string p_strFile);
 
 		/// <summary>
 		/// Retrieves the list of files in this Mod.

--- a/NexusClient.sln
+++ b/NexusClient.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Game Modes", "Game Modes", "{512B02AB-C927-4F3F-A7BF-26E6EE4CF678}"
 EndProject
@@ -398,5 +398,8 @@ Global
 		{C6BA9724-B13B-4FAC-9E79-BA61E8B9334A} = {512B02AB-C927-4F3F-A7BF-26E6EE4CF678}
 		{0D79098F-BEFC-431D-A4E2-1C4FA12C1F03} = {512B02AB-C927-4F3F-A7BF-26E6EE4CF678}
 		{7EEFB043-53CB-419D-89B4-69F5958E9629} = {512B02AB-C927-4F3F-A7BF-26E6EE4CF678}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5F86C40E-2D9A-4720-8C7D-E3252AA108CB}
 	EndGlobalSection
 EndGlobal

--- a/NexusClient/ModManagement/InstallationLog/InstallLog.DummyMod.cs
+++ b/NexusClient/ModManagement/InstallationLog/InstallLog.DummyMod.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.IO;
-using System.Text.RegularExpressions;
-using System.Xml;
 using Nexus.Client.ModManagement.Scripting;
 using Nexus.Client.Mods;
 using Nexus.Client.Util;
@@ -158,6 +155,16 @@ namespace Nexus.Client.ModManagement.InstallationLog
 			{
 				throw new FileNotFoundException("This mod contians no files.");
 			}
+
+            /// <summary>
+			/// Retrieves a FileStream of the specified file from the mod.
+			/// </summary>
+			/// <param name="p_strFile">The file to retrieve stream for.</param>
+			/// <returns>The requested file stream.</returns>
+            public FileStream GetFileStream(string p_strFile)
+            {
+                throw new FileNotFoundException("This mod contians no files.");
+            }
 
 			/// <summary>
 			/// Retrieves the list of files in this Mod.

--- a/NexusClient/ModManagement/InstallationLog/InstallLog.DummyMod.cs
+++ b/NexusClient/ModManagement/InstallationLog/InstallLog.DummyMod.cs
@@ -153,7 +153,7 @@ namespace Nexus.Client.ModManagement.InstallationLog
 			/// is not in the mod.</exception>
 			public byte[] GetFile(string p_strFile)
 			{
-				throw new FileNotFoundException("This mod contians no files.");
+				throw new FileNotFoundException("This mod contains no files.");
 			}
 
             /// <summary>
@@ -163,7 +163,7 @@ namespace Nexus.Client.ModManagement.InstallationLog
 			/// <returns>The requested file stream.</returns>
             public FileStream GetFileStream(string p_strFile)
             {
-                throw new FileNotFoundException("This mod contians no files.");
+                throw new FileNotFoundException("This mod contains no files.");
             }
 
 			/// <summary>

--- a/NexusClient/ModManagement/ModFileUpgradeInstaller.cs
+++ b/NexusClient/ModManagement/ModFileUpgradeInstaller.cs
@@ -50,8 +50,9 @@ namespace Nexus.Client.ModManagement
 		/// <param name="p_tfmFileManager">The transactional file manager to use to interact with the file system.</param>
 		/// <param name="p_dlgOverwriteConfirmationDelegate">The method to call in order to confirm an overwrite.</param>
 		/// <param name="p_UsesPlugins">Game using plugin or mods (True for plugins).</param>
-		public ModFileUpgradeInstaller(IGameModeEnvironmentInfo p_gmiGameModeInfo, IMod p_modMod, IInstallLog p_ilgInstallLog, IPluginManager p_pmgPluginManager, IDataFileUtil p_dfuDataFileUtility, TxFileManager p_tfmFileManager, ConfirmItemOverwriteDelegate p_dlgOverwriteConfirmationDelegate, bool p_UsesPlugins)
-			:base(p_gmiGameModeInfo, p_modMod, p_ilgInstallLog, p_pmgPluginManager, p_dfuDataFileUtility, p_tfmFileManager, p_dlgOverwriteConfirmationDelegate, p_UsesPlugins)
+        /// <param name="p_eifEnvironmentInfo">Environment info for the entire program.</param>
+		public ModFileUpgradeInstaller(IGameModeEnvironmentInfo p_gmiGameModeInfo, IMod p_modMod, IInstallLog p_ilgInstallLog, IPluginManager p_pmgPluginManager, IDataFileUtil p_dfuDataFileUtility, TxFileManager p_tfmFileManager, ConfirmItemOverwriteDelegate p_dlgOverwriteConfirmationDelegate, bool p_UsesPlugins, IEnvironmentInfo p_eifEnvironmentInfo)
+			:base(p_gmiGameModeInfo, p_modMod, p_ilgInstallLog, p_pmgPluginManager, p_dfuDataFileUtility, p_tfmFileManager, p_dlgOverwriteConfirmationDelegate, p_UsesPlugins, p_eifEnvironmentInfo)
 		{
 			OriginallyInstalledFiles = new Set<string>(StringComparer.OrdinalIgnoreCase);
 			foreach (string strFile in InstallLog.GetInstalledModFiles(Mod))

--- a/NexusClient/ModManagement/ModInstaller.cs
+++ b/NexusClient/ModManagement/ModInstaller.cs
@@ -377,7 +377,7 @@ namespace Nexus.Client.ModManagement
 		/// <returns>The file installer to use to install the mod's files.</returns>
 		protected virtual IModFileInstaller CreateFileInstaller(TxFileManager p_tfmFileManager, ConfirmItemOverwriteDelegate p_dlgOverwriteConfirmationDelegate)
 		{
-			return new ModFileInstaller(GameMode.GameModeEnvironmentInfo, Mod, ModInstallLog, PluginManager, new DataFileUtil(GameMode.GameModeEnvironmentInfo.InstallationPath), p_tfmFileManager, p_dlgOverwriteConfirmationDelegate, GameMode.UsesPlugins);
+			return new ModFileInstaller(GameMode.GameModeEnvironmentInfo, Mod, ModInstallLog, PluginManager, new DataFileUtil(GameMode.GameModeEnvironmentInfo.InstallationPath), p_tfmFileManager, p_dlgOverwriteConfirmationDelegate, GameMode.UsesPlugins, EnvironmentInfo);
 		}
 
 		/// <summary>

--- a/NexusClient/ModManagement/ModUninstaller.cs
+++ b/NexusClient/ModManagement/ModUninstaller.cs
@@ -185,7 +185,7 @@ namespace Nexus.Client.ModManagement
 			p_strErrorMessage = null;
 			IDataFileUtil dfuDataFileUtility = new DataFileUtil(GameMode.GameModeEnvironmentInfo.InstallationPath);
 
-			IModFileInstaller mfiFileInstaller = new ModFileInstaller(GameMode.GameModeEnvironmentInfo, Mod, ModInstallLog, PluginManager, dfuDataFileUtility, p_tfmFileManager, null, GameMode.UsesPlugins);
+			IModFileInstaller mfiFileInstaller = new ModFileInstaller(GameMode.GameModeEnvironmentInfo, Mod, ModInstallLog, PluginManager, dfuDataFileUtility, p_tfmFileManager, null, GameMode.UsesPlugins, EnvironmentInfo);
 			IIniInstaller iniIniInstaller = new IniInstaller(Mod, ModInstallLog, VirtualModActivator, p_tfmFileManager, null);
 			IGameSpecificValueInstaller gviGameSpecificValueInstaller = GameMode.GetGameSpecificValueInstaller(Mod, ModInstallLog, p_tfmFileManager, new NexusFileUtil(EnvironmentInfo), null);
 

--- a/NexusClient/ModManagement/ModUpgrader.cs
+++ b/NexusClient/ModManagement/ModUpgrader.cs
@@ -65,7 +65,7 @@ namespace Nexus.Client.ModManagement
 		/// <returns>The file installer to use to install the mod's files.</returns>
 		protected override IModFileInstaller CreateFileInstaller(TxFileManager p_tfmFileManager, ConfirmItemOverwriteDelegate p_dlgOverwriteConfirmationDelegate)
 		{
-			return new ModFileUpgradeInstaller(GameMode.GameModeEnvironmentInfo, Mod, ModInstallLog, PluginManager, new DataFileUtil(GameMode.GameModeEnvironmentInfo.InstallationPath), p_tfmFileManager, p_dlgOverwriteConfirmationDelegate, GameMode.UsesPlugins);
+			return new ModFileUpgradeInstaller(GameMode.GameModeEnvironmentInfo, Mod, ModInstallLog, PluginManager, new DataFileUtil(GameMode.GameModeEnvironmentInfo.InstallationPath), p_tfmFileManager, p_dlgOverwriteConfirmationDelegate, GameMode.UsesPlugins, EnvironmentInfo);
 		}
 
 		/// <summary>

--- a/OMod/OMod.cs
+++ b/OMod/OMod.cs
@@ -72,6 +72,8 @@ namespace Nexus.Client.Mods.Formats.OMod
 
 		private bool m_booAllowArchiveEdits = false;
 
+        private IEnvironmentInfo m_eifEnvironmentInfo;
+
 		#endregion
 
 		#region Properties
@@ -550,7 +552,8 @@ namespace Nexus.Client.Mods.Formats.OMod
 		/// <param name="p_stgScriptTypeRegistry">The registry of supported script types.</param>
 		public OMod(string p_strFilePath, OModFormat p_mftModFormat, IModCacheManager p_mcmModCacheManager, IScriptTypeRegistry p_stgScriptTypeRegistry)
 		{
-			Format = p_mftModFormat;
+            m_eifEnvironmentInfo = p_mcmModCacheManager.EnvironmentInfo;
+            Format = p_mftModFormat;
 			m_strFilePath = p_strFilePath;
             m_dtDownloadDate = File.GetLastWriteTime(m_strFilePath);
             m_arcFile = new Archive(p_strFilePath);
@@ -1299,11 +1302,22 @@ namespace Nexus.Client.Mods.Formats.OMod
 			return bteFile;
 		}
 
-		/// <summary>
-		/// Retrieves the list of files in this OMod.
+        /// <summary>
+		/// Retrieves stream for the specified file from the OMod.
 		/// </summary>
-		/// <returns>The list of files in this OMod.</returns>
-		public List<string> GetFileList()
+		/// <param name="p_strFile">The file to retrieve.</param>
+		/// <returns>Stream for the requested file data.</returns>
+		public FileStream GetFileStream(string p_strFile)
+        {
+            // TODO : SQUID-BOX
+            throw new NotImplementedException("Could not be bothered tonight.");
+        }
+
+        /// <summary>
+        /// Retrieves the list of files in this OMod.
+        /// </summary>
+        /// <returns>The list of files in this OMod.</returns>
+        public List<string> GetFileList()
 		{
 			return GetFileList(null, true);
 		}

--- a/OMod/OMod.cs
+++ b/OMod/OMod.cs
@@ -1322,12 +1322,13 @@ namespace Nexus.Client.Mods.Formats.OMod
 
                 if ((Directory.Exists(m_strCachePath) && (File.Exists(Path.Combine(m_strCachePath, GetRealPath(p_strFile))))))
                 {
-                    strPath = Path.Combine(m_strCachePath, GetRealPath(p_strFile));
-                    
+                    strPath = Path.Combine(m_strCachePath, GetRealPath(p_strFile));                    
                 }
-
-                strPath = GetRealPath(p_strFile);
-
+                else
+                {
+                    strPath = GetRealPath(p_strFile);
+                }
+                
                 return new FileStream(strPath, FileMode.Open);
             }
 
@@ -1338,7 +1339,7 @@ namespace Nexus.Client.Mods.Formats.OMod
 
             List<FileInfo> lstFiles = null;
 
-            string strTempFile = Path.Combine(m_eifEnvironmentInfo.TemporaryPath, Path.GetTempFileName());
+            string strTempFile = Path.Combine(m_eifEnvironmentInfo.TemporaryPath, "tempfile_" + Path.GetRandomFileName());
 
             using (Stream stmDataFiles = new MemoryStream())
             {

--- a/Util/Archive.cs
+++ b/Util/Archive.cs
@@ -625,47 +625,47 @@ namespace Nexus.Client.Util
         public FileStream GetFileStream(string p_strPath, string p_strTemporaryDirectory)
         {
             string strPath = p_strPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
-            var tmpFile = Path.Combine(p_strTemporaryDirectory, Path.GetRandomFileName());
-
-            FileStream stream;
-
+            string strTempFile = Path.Combine(p_strTemporaryDirectory, "tempfile_" + Path.GetRandomFileName());
+            
             if (!m_dicFileInfo.ContainsKey(strPath))
             {
                 throw new FileNotFoundException("The requested file does not exist in the archive.", p_strPath);
             }
             
             ArchiveFileInfo afiFile = m_dicFileInfo[strPath];
-            
+
+            string strFilePath;
+
             if (IsReadonly)
             {
                 if (m_szeReadOnlyExtractor == null)
                 {
-                    stream = new FileStream(Path.Combine(m_strReadOnlyTempDirectory, strPath), FileMode.Open);
+                    strFilePath = Path.Combine(m_strReadOnlyTempDirectory, strPath);
                 }
                 else
                 {
-                    using (var sw = new StreamWriter(tmpFile, false))
+                    using (var sw = new StreamWriter(strTempFile, false))
                     {
                         m_szeReadOnlyExtractor.ExtractFile(afiFile.Index, sw.BaseStream);
                     }
 
-                    stream = new FileStream(tmpFile, FileMode.Open);                    
+                    strFilePath = strTempFile;
                 }                    
             }
             else
             {
                 using (SevenZipExtractor szeExtractor = GetExtractor(m_strPath))
                 {
-                    using (var sw = new StreamWriter(tmpFile, false))
+                    using (var sw = new StreamWriter(strTempFile, false))
                     {
                         szeExtractor.ExtractFile(afiFile.Index, sw.BaseStream);
                     }
 
-                    stream = new FileStream(tmpFile, FileMode.Open);
+                    strFilePath = strTempFile;
                 }
             }
 
-            return stream;
+            return new FileStream(strFilePath, FileMode.Open);
         }
 
 		/// <summary>

--- a/Util/Archive.cs
+++ b/Util/Archive.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Windows.Forms;
 using Nexus.Client.Util.Collections;
 using SevenZip;
 
@@ -645,10 +644,9 @@ namespace Nexus.Client.Util
                 }
                 else
                 {
-                    using (var sr = new StreamWriter(tmpFile, false) { AutoFlush = true })
+                    using (var sw = new StreamWriter(tmpFile, false))
                     {
-                        m_szeReadOnlyExtractor.ExtractFile(afiFile.Index, sr.BaseStream);
-                        sr.Close();
+                        m_szeReadOnlyExtractor.ExtractFile(afiFile.Index, sw.BaseStream);
                     }
 
                     stream = new FileStream(tmpFile, FileMode.Open);                    
@@ -658,13 +656,12 @@ namespace Nexus.Client.Util
             {
                 using (SevenZipExtractor szeExtractor = GetExtractor(m_strPath))
                 {
-                    using (var sr = new StreamWriter(tmpFile, false) { AutoFlush = true })
+                    using (var sw = new StreamWriter(tmpFile, false))
                     {
-                        szeExtractor.ExtractFile(afiFile.Index, sr.BaseStream);
-                        sr.Close();
+                        szeExtractor.ExtractFile(afiFile.Index, sw.BaseStream);
                     }
 
-                    stream = new FileStream(tmpFile, FileMode.Open);                               
+                    stream = new FileStream(tmpFile, FileMode.Open);
                 }
             }
 


### PR DESCRIPTION
This aims to resolve #225. There was a bit more to change than I first expected, I'm still not sure on the use of temporary files, but I have no better suggestion at the time.

tl;dr: Files are extracted to a temporary file, a FileStream pointing to the temporary file (or an already cached file) is passed through the enormous chain, and then copied to the proper place (through TxFileManager). After this, any extracted temporary files are removed (they would be removed on exiting NMM, but given that I'm adding support for large files (upwards of 11GB each) it seems prudent to not leave them for the entire session.

I've tested it as far as I can, but I'm not 100% sure of what OMod's should work (but comparing to the current release, my fix behaves the same) 🤷‍♂️