### PR TITLE
Don't deactivate official unmanaged plugins

### DIFF
--- a/NexusClient/PluginManagement/UI/PluginManagerVM.cs
+++ b/NexusClient/PluginManagement/UI/PluginManagerVM.cs
@@ -244,6 +244,18 @@ namespace Nexus.Client.PluginManagement.UI
 			}
 		}
 
+        /// <summary>
+		/// Gets the list of official, unmanaged, plugin names, ordered by load order.
+		/// </summary>
+		/// <value>The list of official, unmanaged, plugin names, ordered by load order.</value>
+        public string[] OrderedOfficialUnmanagedPluginNames
+        {
+            get
+            {
+                return CurrentGameMode.OrderedOfficialUnmanagedPluginNames;
+            }
+        }
+
         #endregion
 
         #region Constructors
@@ -423,11 +435,14 @@ namespace Nexus.Client.PluginManagement.UI
 		{
 			List<Plugin> lstActivePlugins = ActivePlugins.ToList();
 
-			foreach (string criticalPlugin in OrderedCriticalPluginNames)
+            // Remove all critical or unmanaged plugins from the list of plugins to deactivate.
+            foreach (string ignoredPlugin in OrderedCriticalPluginNames.Concat(OrderedOfficialUnmanagedPluginNames))
 			{
-				Plugin plgCritical = PluginManager.GetRegisteredPlugin(criticalPlugin);
-				if (plgCritical != null)
-					lstActivePlugins.Remove(plgCritical);
+				var plgIgnored = PluginManager.GetRegisteredPlugin(ignoredPlugin);
+				if (plgIgnored != null)
+                {
+                    lstActivePlugins.Remove(plgIgnored);
+                }
 			}
 
 			ManagingMultiplePlugins(this, new EventArgs<IBackgroundTask>(PluginManager.ManageMultiplePluginsTask(lstActivePlugins, false, ConfirmUpdaterAction)));


### PR DESCRIPTION
Currently, if you click "Disable all active plugins" NMM will disable also any plugin listed under OFFICIAL_UNMANAGED_PLUGINS. These plugins cannot be reactivated manually (checkbox is greyed out), to restore these you'll have to reactivate all plugins.

This simple fix removes also the official unmanaged plugins from the list of plugins to deactivate.