### PR TITLE
Use .ccc files to read official unmanaged plugins

### DIFF
--- a/Fallout4/Fallout4GameModeDescriptor.cs
+++ b/Fallout4/Fallout4GameModeDescriptor.cs
@@ -1,4 +1,6 @@
 ﻿using System.Drawing;
+using System.IO;
+using System.Linq;
 using Nexus.Client.Games.Gamebryo;
 
 namespace Nexus.Client.Games.Fallout4
@@ -11,30 +13,10 @@ namespace Nexus.Client.Games.Fallout4
 		private static string[] EXECUTABLES = { "Fallout4Launcher.exe" };
 		private static string[] CRITICAL_PLUGINS = { "Fallout4.esm" };
 		private static string[] OFFICIAL_PLUGINS = { "DLCRobot.esm", "DLCworkshop01.esm", "DLCCoast.esm", "DLCworkshop02.esm", "DLCworkshop03.esm", "DLCNukaWorld.esm" };
-        private static string[] OFFICIAL_UNMANAGED_PLUGINS = { "DLCRobot.esm", "DLCworkshop01.esm", "DLCCoast.esm", "DLCworkshop02.esm", "DLCworkshop03.esm", "DLCNukaWorld.esm",
-																"ccbgsfo4001-pipboy(black).esl",
-																"ccbgsfo4002-pipboy(blue).esl",
-																"ccbgsfo4003-pipboy(camo01).esl",
-																"ccbgsfo4004-pipboy(camo02).esl",
-																"ccbgsfo4006-pipboy(chrome).esl",
-																"ccbgsfo4012-pipboy(red).esl",
-																"ccbgsfo4014-pipboy(white).esl",
-																"ccbgsfo4016-prey.esl",
-																"ccbgsfo4017-mauler.esl",
-																"ccbgsfo4018-gaussrifleprototype.esl",
-																"ccbgsfo4019-chinesestealtharmor.esl",
-																"ccbgsfo4020-powerarmorskin(black).esl",
-																"ccbgsfo4038-horsearmor.esl",
-																"ccbgsfo4039-tunnelsnakes.esl",
-																"ccbgsfo4041-doommarinearmor.esl",
-																"ccbgsfo4042-bfg.esl",
-																"ccbgsfo4043-doomchainsaw.esl",
-																"ccbgsfo4044-hellfirepowerarmor.esl",
-																"ccfsvfo4001-modularmilitarybackpack.esl",
-																"ccfsvfo4002-midcenturymodern.esl",
-																"ccfrsfo4001-handmadeshotgun.esl",
-																"cceejfo4001-decorationpack.esl" };
+        private static string[] OFFICIAL_UNMANAGED_PLUGINS = { "DLCRobot.esm", "DLCworkshop01.esm", "DLCCoast.esm", "DLCworkshop02.esm", "DLCworkshop03.esm", "DLCNukaWorld.esm" };
         private const string MODE_ID = "Fallout4";
+
+        private bool m_booCheckedCccFile;
 
 		#region Properties
 
@@ -106,6 +88,18 @@ namespace Nexus.Client.Games.Fallout4
         {
             get
             {
+                if (!m_booCheckedCccFile)
+                {
+                    m_booCheckedCccFile = true;
+
+                    if (File.Exists(Path.Combine(InstallationPath, "Fallout4.ccc")))
+                    {
+                        var lines = File.ReadLines(Path.Combine(InstallationPath, "Fallout4.ccc")).Where(line => !string.IsNullOrEmpty(line));
+                        OFFICIAL_UNMANAGED_PLUGINS = OFFICIAL_UNMANAGED_PLUGINS.Union(lines).ToArray();
+                        m_booCheckedCccFile = true;
+                    }
+                }
+
                 return OFFICIAL_UNMANAGED_PLUGINS;
             }
         }

--- a/SkyrimSE/SkyrimSEGameModeDescriptor.cs
+++ b/SkyrimSE/SkyrimSEGameModeDescriptor.cs
@@ -1,4 +1,6 @@
 ﻿using System.Drawing;
+using System.IO;
+using System.Linq;
 using Nexus.Client.Games.Gamebryo;
 
 namespace Nexus.Client.Games.SkyrimSE
@@ -11,17 +13,10 @@ namespace Nexus.Client.Games.SkyrimSE
 		private static string[] EXECUTABLES = { "SkyrimSELauncher.exe" };
 		private static string[] CRITICAL_PLUGINS = { "Skyrim.esm", "Update.esm" , "Dawnguard.esm", "HearthFires.esm", "Dragonborn.esm" };
 		private static string[] OFFICIAL_PLUGINS = { };
-        private static string[] OFFICIAL_UNMANAGED_PLUGINS = { "ccBGSSSE002-ExoticArrows.esl",
-																"ccBGSSSE003-Zombies.esl",
-																"ccBGSSSE004-RuinsEdge.esl",
-																"ccBGSSSE006-StendarsHammer.esl",
-																"ccBGSSSE007-Chrysamere.esl",
-																"ccBGSSSE010-PetDwarvenArmoredMudcrab.esl",
-																"ccBGSSSE014-SpellPack01.esl",
-																"ccBGSSSE019-StaffofSheogorath.esl",
-																"ccMTYSSE001-KnightsoftheNine.esl",
-																"ccQDRSSE001-SurvivalMode.esl" };
+        private static string[] OFFICIAL_UNMANAGED_PLUGINS = { };
         private const string MODE_ID = "SkyrimSE";
+
+        private bool m_booCheckedCccFile;
 
 		#region Properties
 
@@ -93,7 +88,17 @@ namespace Nexus.Client.Games.SkyrimSE
 		{
 			get
 			{
-				return OFFICIAL_UNMANAGED_PLUGINS;
+                if (!m_booCheckedCccFile)
+                {
+                    m_booCheckedCccFile = true;
+
+                    if (File.Exists(Path.Combine(InstallationPath, "Skyrim.ccc")))
+                    {
+                        OFFICIAL_UNMANAGED_PLUGINS = File.ReadLines(Path.Combine(InstallationPath, "Skyrim.ccc")).Where(line => !string.IsNullOrEmpty(line)).ToArray();
+                    }
+                }
+
+                return OFFICIAL_UNMANAGED_PLUGINS;
 			}
 		}
 


### PR DESCRIPTION
Suggested solution to close #173 and #247.

Applies to Fallout 4 and Skyrim SE (I believe those are the only ones with CC support). Will try to read contents of Skyrim.ccc or Fallout4.ccc the first time _OFFICIAL_UNMANAGED_PLUGINS_ is requested.