### PR TITLE
Fixed archive invalidation for FO4 and SSE (+Skyrim LE DLCs)

### DIFF
--- a/Fallout4/Tools/AI/ArchiveInvalidation.cs
+++ b/Fallout4/Tools/AI/ArchiveInvalidation.cs
@@ -85,17 +85,29 @@ namespace Nexus.Client.Games.Fallout4.Tools.AI
 			CloseToolView(this, teaArgs);
 		}
 
-		/// <summary>
-		/// Enables AI.
-		/// </summary>
-		protected void ApplyAI()
-		{
-			if (ConfirmAiReset())
-			{
-				string strPluginsPath = GameMode.PluginDirectory;
-				foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("Fallout4 - *.bsa"))
-					fi.LastWriteTime = new DateTime(2008, 10, 1);
-			}
-		}
+        /// <summary>
+        /// Enables AI.
+        /// </summary>
+        protected void ApplyAI()
+        {
+            if (ConfirmAiReset())
+            {
+                string strPluginsPath = GameMode.PluginDirectory;
+                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("Fallout4 - *.ba2"))
+                    fi.LastWriteTime = new DateTime(2008, 10, 1);
+                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("DLCRobot - *.ba2"))
+                    fi.LastWriteTime = new DateTime(2008, 10, 2);
+                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("DLCworkshop01 - *.ba2"))
+                    fi.LastWriteTime = new DateTime(2008, 10, 3);
+                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("DLCCoast - *.ba2"))
+                    fi.LastWriteTime = new DateTime(2008, 10, 4);
+                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("DLCworkshop02 - *.ba2"))
+                    fi.LastWriteTime = new DateTime(2008, 10, 5);
+                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("DLCworkshop03 - *.ba2"))
+                    fi.LastWriteTime = new DateTime(2008, 10, 6);
+                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("DLCNukaWorld - *.ba2"))
+                    fi.LastWriteTime = new DateTime(2008, 10, 7);
+            }
+        }
 	}
 }

--- a/Skyrim/Tools/AI/ArchiveInvalidation.cs
+++ b/Skyrim/Tools/AI/ArchiveInvalidation.cs
@@ -85,17 +85,27 @@ namespace Nexus.Client.Games.Skyrim.Tools.AI
 			CloseToolView(this, teaArgs);
 		}
 
-		/// <summary>
-		/// Enables AI.
-		/// </summary>
-		protected void ApplyAI()
-		{
-			if (ConfirmAiReset())
-			{
-				string strPluginsPath = GameMode.PluginDirectory;
-				foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("Skyrim - *.bsa"))
-					fi.LastWriteTime = new DateTime(2008, 10, 1);
-			}
-		}
+        /// <summary>
+        /// Enables AI.
+        /// </summary>
+        protected void ApplyAI()
+        {
+            if (ConfirmAiReset())
+            {
+                string strPluginsPath = GameMode.PluginDirectory;
+                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("Skyrim - *.bsa"))
+                    fi.LastWriteTime = new DateTime(2008, 10, 1);
+                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("Update.bsa"))
+                    fi.LastWriteTime = new DateTime(2008, 10, 2);
+                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("Dawnguard.bsa"))
+                    fi.LastWriteTime = new DateTime(2008, 10, 3);
+                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("HearthFires.bsa"))
+                    fi.LastWriteTime = new DateTime(2008, 10, 4);
+                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("Dragonborn.bsa"))
+                    fi.LastWriteTime = new DateTime(2008, 10, 5);
+                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("HighResTexturePack*.bsa"))
+                    fi.LastWriteTime = new DateTime(2008, 10, 6);
+            }
+        }
 	}
 }

--- a/SkyrimSE/Tools/AI/ArchiveInvalidation.cs
+++ b/SkyrimSE/Tools/AI/ArchiveInvalidation.cs
@@ -85,17 +85,17 @@ namespace Nexus.Client.Games.SkyrimSE.Tools.AI
 			CloseToolView(this, teaArgs);
 		}
 
-		/// <summary>
-		/// Enables AI.
-		/// </summary>
-		protected void ApplyAI()
-		{
-			if (ConfirmAiReset())
-			{
-				string strPluginsPath = GameMode.PluginDirectory;
-				foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("SkyrimSE - *.bsa"))
-					fi.LastWriteTime = new DateTime(2008, 10, 1);
-			}
-		}
+        /// <summary>
+        /// Enables AI.
+        /// </summary>
+        protected void ApplyAI()
+        {
+            if (ConfirmAiReset())
+            {
+                string strPluginsPath = GameMode.PluginDirectory;
+                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("Skyrim - *.bsa"))
+                    fi.LastWriteTime = new DateTime(2008, 10, 1);
+            }
+        }
 	}
 }


### PR DESCRIPTION
Especially in FO4 with the required Fallout4Custom.ini tweak, this caused a whole lot of mods that replace vanilla files to not work properly, even more so after updates to the game (Fallout4 - Meshes.ba2).

Fixed it for:
- FO4 (*.ba2 instead of *.bsa) and added DLCs
- SSE (Skyrim* instead of SkyrimSE*)

Also added the DLCs for Skyrim LE.