### PR TITLE
Fixed problem causing mods to not be installable

### DIFF
--- a/OMod/OMod.cs
+++ b/OMod/OMod.cs
@@ -1341,6 +1341,11 @@ namespace Nexus.Client.Mods.Formats.OMod
 
             string strTempFile = Path.Combine(m_eifEnvironmentInfo.TemporaryPath, "tempfile_" + Path.GetRandomFileName());
 
+            if (!Directory.Exists(m_eifEnvironmentInfo.TemporaryPath))
+            {
+                Directory.CreateDirectory(m_eifEnvironmentInfo.TemporaryPath);
+            }
+
             using (Stream stmDataFiles = new MemoryStream())
             {
                 using (SevenZipExtractor szeOmod = new SevenZipExtractor(m_strFilePath))

--- a/Util/Archive.cs
+++ b/Util/Archive.cs
@@ -627,6 +627,11 @@ namespace Nexus.Client.Util
             string strPath = p_strPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
             string strTempFile = Path.Combine(p_strTemporaryDirectory, "tempfile_" + Path.GetRandomFileName());
             
+            if (!Directory.Exists(p_strTemporaryDirectory))
+            {
+                Directory.CreateDirectory(p_strTemporaryDirectory);
+            }
+
             if (!m_dicFileInfo.ContainsKey(strPath))
             {
                 throw new FileNotFoundException("The requested file does not exist in the archive.", p_strPath);


### PR DESCRIPTION
Sometimes the NMM temp folder is not created, and #236 did not consider that case. This caused mod installations to fail with a message stating:

![image](https://user-images.githubusercontent.com/864820/36345071-aff0b636-1424-11e8-9004-66002404c217.png)
