### PR TITLE
Fix download IO performance and reduce scope of game search to fixed drives

### DIFF
--- a/NexusClient/Games/FileSearcher.cs
+++ b/NexusClient/Games/FileSearcher.cs
@@ -106,7 +106,7 @@ namespace Nexus.Client.Games
 
 			Queue<string> queSearchPaths = new Queue<string>();
 			foreach (DriveInfo difDrive in difDrives)
-				if ((difDrive.DriveType != DriveType.CDRom) && difDrive.IsReady)
+				if (difDrive.DriveType == DriveType.Fixed && difDrive.IsReady)
 					queSearchPaths.Enqueue(difDrive.Name);
 			Int32 intFOlderCnt = 0;
 			while (queSearchPaths.Count > 0)


### PR DESCRIPTION
Download performance is currently terrible due to the constant opening/closing of file handles. It is so slow, it locks up the application when trying to pause, and prevents it from closing while it waits for the file writer to catch up. For large downloads, especially with a premium account, it could easily fall behind several hours. During that time, the whole download is eating into memory waiting to be written also.

Also changed the file searcher to only look at "Fixed" drives, instead of "Not CDRom" since it was still searching network and external USB drives and such. At the very least, it definitely shouldn't be scanning network drives.