### PR TITLE
Added launch parameters to LOOT for supported games.

### DIFF
--- a/Fallout3/Fallout3SupportedTools.cs
+++ b/Fallout3/Fallout3SupportedTools.cs
@@ -84,8 +84,8 @@ namespace Nexus.Client.Games.Fallout3
 			Trace.Indent();
 			string strCommand = GetLOOTLaunchCommand();
 			Trace.TraceInformation("Command: " + strCommand);
-			Launch(strCommand, null);
-		}
+            Launch(strCommand, "--game=Fallout3");
+        }
 
 		/// <summary>
 		/// Gets the BOSS launch command.

--- a/Fallout4/Fallout4SupportedTools.cs
+++ b/Fallout4/Fallout4SupportedTools.cs
@@ -88,7 +88,7 @@ namespace Nexus.Client.Games.Fallout4
 			Trace.Indent();
 			string strCommand = GetLOOTLaunchCommand();
 			Trace.TraceInformation("Command: " + strCommand);
-			Launch(strCommand, null);
+			Launch(strCommand, "--game=Fallout4");
 		}
 				
 		private void LaunchFO4Edit()

--- a/FalloutNV/FalloutNVSupportedTools.cs
+++ b/FalloutNV/FalloutNVSupportedTools.cs
@@ -83,7 +83,7 @@ namespace Nexus.Client.Games.FalloutNV
 			Trace.Indent();
 			string strCommand = GetLOOTLaunchCommand();
 			Trace.TraceInformation("Command: " + strCommand);
-			Launch(strCommand, null);
+			Launch(strCommand, "--game=FalloutNV");
 		}
 
 		/// <summary>

--- a/Oblivion/OblivionSupportedTools.cs
+++ b/Oblivion/OblivionSupportedTools.cs
@@ -106,8 +106,8 @@ namespace Nexus.Client.Games.Oblivion
 			Trace.Indent();
 			string strCommand = GetLOOTLaunchCommand();
 			Trace.TraceInformation("Command: " + strCommand);
-			Launch(strCommand, null);
-		}
+            Launch(strCommand, "--game=Oblivion");
+        }
 
 		/// <summary>
 		/// Gets the BOSS launch command.

--- a/Skyrim/SkyrimSupportedTools.cs
+++ b/Skyrim/SkyrimSupportedTools.cs
@@ -162,8 +162,8 @@ namespace Nexus.Client.Games.Skyrim
 			Trace.Indent();
 			string strCommand = GetLOOTLaunchCommand();
 			Trace.TraceInformation("Command: " + strCommand);
-			Launch(strCommand, null);
-		}
+            Launch(strCommand, "--game=Skyrim");
+        }
 
 		private void LaunchWryeBash()
 		{

--- a/SkyrimSE/SkyrimSESupportedTools.cs
+++ b/SkyrimSE/SkyrimSESupportedTools.cs
@@ -162,8 +162,8 @@ namespace Nexus.Client.Games.SkyrimSE
 			Trace.Indent();
 			string strCommand = GetLOOTLaunchCommand();
 			Trace.TraceInformation("Command: " + strCommand);
-			Launch(strCommand, null);
-		}
+            Launch(strCommand, "--game=Skyrim");
+        }
 
 		private void LaunchWryeBash()
 		{


### PR DESCRIPTION
I've gone through and added [LOOT launch parameters](https://loot.github.io/docs/0.9.2/LOOT%20Readme.html#usage-init) for the games that are supported by it. I've only tested on Fallout 4, but the change seems trivial enough to include the other games as well.

This fixes issue #42.