### PR TITLE
Detect incompatible file systems

### DIFF
--- a/NexusClient/Games/GameModeDiscoveredEventArgs.cs
+++ b/NexusClient/Games/GameModeDiscoveredEventArgs.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
 
 namespace Nexus.Client.Games
 {
@@ -22,6 +24,11 @@ namespace Nexus.Client.Games
 		/// <value>The installation path that was found.</value>
 		public string InstallationPath { get; private set; }
 
+        /// <summary>
+        /// Gets a value determining whether or not the game is installed on a file system that supports symbolic linking.
+        /// </summary>
+        public bool InstalledOnSuitableFileSystem { get; private set; }
+
 		#endregion
 
 		#region Constructors
@@ -35,7 +42,36 @@ namespace Nexus.Client.Games
 		{
 			GameMode = p_gmdGameModeInfo;
 			InstallationPath = p_strInstallationPath;
-		}
+            InstalledOnSuitableFileSystem = DoesFileSystemSupportSymbolicLinks(p_strInstallationPath);            
+        }
+
+        /// <summary>
+        /// Determines if the file system of the drive is suitable for NMM to use.
+        /// </summary>
+        /// <param name="p_strPath">Path to folder on drive we want to check.</param>
+        /// <returns>True if we expect NMM to be able to use the drive in question, otherwise false.</returns>
+        private static bool DoesFileSystemSupportSymbolicLinks(string p_strPath)
+        {
+            if (string.IsNullOrEmpty(p_strPath))
+            {
+                // Won't matter if there's no path.
+                return true;
+            }
+
+            // This list can be extended as needed, and is not case sensitive.
+            var knownBadFileSystems = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "FAT",
+                "FAT32",
+                "ReFS",
+                "exFAT"
+            };
+
+            var file = new FileInfo(p_strPath);
+            var drive = new DriveInfo(file.Directory.Root.FullName);
+
+            return !knownBadFileSystems.Contains(drive.DriveFormat);
+        }
 
 		#endregion
 	}

--- a/NexusClient/Games/GameModeDiscoveredEventArgs.cs
+++ b/NexusClient/Games/GameModeDiscoveredEventArgs.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
 
 namespace Nexus.Client.Games
 {
@@ -42,36 +40,8 @@ namespace Nexus.Client.Games
 		{
 			GameMode = p_gmdGameModeInfo;
 			InstallationPath = p_strInstallationPath;
-            InstalledOnSuitableFileSystem = DoesFileSystemSupportSymbolicLinks(p_strInstallationPath);            
-        }
-
-        /// <summary>
-        /// Determines if the file system of the drive is suitable for NMM to use.
-        /// </summary>
-        /// <param name="p_strPath">Path to folder on drive we want to check.</param>
-        /// <returns>True if we expect NMM to be able to use the drive in question, otherwise false.</returns>
-        private static bool DoesFileSystemSupportSymbolicLinks(string p_strPath)
-        {
-            if (string.IsNullOrEmpty(p_strPath))
-            {
-                // Won't matter if there's no path.
-                return true;
-            }
-
-            // This list can be extended as needed, and is not case sensitive.
-            var knownBadFileSystems = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-            {
-                "FAT",
-                "FAT32",
-                "ReFS",
-                "exFAT"
-            };
-
-            var file = new FileInfo(p_strPath);
-            var drive = new DriveInfo(file.Directory.Root.FullName);
-
-            return !knownBadFileSystems.Contains(drive.DriveFormat);
-        }
+            InstalledOnSuitableFileSystem = Util.FileUtil.DoesFileSystemSupportSymbolicLinks(p_strInstallationPath);            
+        }        
 
 		#endregion
 	}

--- a/NexusClient/UI/Controls/GameModeSearchListViewItem.Designer.cs
+++ b/NexusClient/UI/Controls/GameModeSearchListViewItem.Designer.cs
@@ -28,345 +28,387 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.components = new System.ComponentModel.Container();
-			this.lblGameModeName = new System.Windows.Forms.Label();
-			this.pnlCandidate = new System.Windows.Forms.Panel();
-			this.label1 = new System.Windows.Forms.Label();
-			this.lblFoundTitle = new System.Windows.Forms.Label();
-			this.butReject = new System.Windows.Forms.Button();
-			this.butAccept = new System.Windows.Forms.Button();
-			this.lblPath = new Nexus.UI.Controls.PathLabel();
-			this.pnlNotFound = new System.Windows.Forms.Panel();
-			this.butOverride = new System.Windows.Forms.Button();
-			this.butSelectPath = new System.Windows.Forms.Button();
-			this.tbxInstallPath = new System.Windows.Forms.TextBox();
-			this.lblNotFoundMessage = new System.Windows.Forms.Label();
-			this.lblNotFoundTitle = new System.Windows.Forms.Label();
-			this.fbdSelectPath = new System.Windows.Forms.FolderBrowserDialog();
-			this.pbxGameLogo = new System.Windows.Forms.PictureBox();
-			this.erpErrors = new System.Windows.Forms.ErrorProvider(this.components);
-			this.panel1 = new System.Windows.Forms.Panel();
-			this.pnlSearching = new System.Windows.Forms.Panel();
-			this.butCancel = new System.Windows.Forms.Button();
-			this.pbrProgress = new System.Windows.Forms.ProgressBar();
-			this.lblSearchingTitle = new System.Windows.Forms.Label();
-			this.lblProgressMessage = new Nexus.UI.Controls.PathLabel();
-			this.pnlSet = new System.Windows.Forms.Panel();
-			this.lblFinalPath = new Nexus.UI.Controls.PathLabel();
-			this.pnlCandidate.SuspendLayout();
-			this.pnlNotFound.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.pbxGameLogo)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.erpErrors)).BeginInit();
-			this.panel1.SuspendLayout();
-			this.pnlSearching.SuspendLayout();
-			this.pnlSet.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// lblGameModeName
-			// 
-			this.lblGameModeName.Dock = System.Windows.Forms.DockStyle.Top;
-			this.m_fpdFontProvider.SetFontSet(this.lblGameModeName, "HeadingText");
-			this.m_fpdFontProvider.SetFontSize(this.lblGameModeName, 20F);
-			this.m_fpdFontProvider.SetFontStyle(this.lblGameModeName, System.Drawing.FontStyle.Bold);
-			this.lblGameModeName.Location = new System.Drawing.Point(0, 0);
-			this.lblGameModeName.Name = "lblGameModeName";
-			this.lblGameModeName.Size = new System.Drawing.Size(388, 31);
-			this.lblGameModeName.TabIndex = 1;
-			this.lblGameModeName.Text = "GAME TITLE";
-			this.lblGameModeName.TextAlign = System.Drawing.ContentAlignment.BottomRight;
-			// 
-			// pnlCandidate
-			// 
-			this.pnlCandidate.Controls.Add(this.label1);
-			this.pnlCandidate.Controls.Add(this.lblFoundTitle);
-			this.pnlCandidate.Controls.Add(this.butReject);
-			this.pnlCandidate.Controls.Add(this.butAccept);
-			this.pnlCandidate.Controls.Add(this.lblPath);
-			this.pnlCandidate.Dock = System.Windows.Forms.DockStyle.Bottom;
-			this.pnlCandidate.Location = new System.Drawing.Point(128, 453);
-			this.pnlCandidate.Name = "pnlCandidate";
-			this.pnlCandidate.Size = new System.Drawing.Size(388, 66);
-			this.pnlCandidate.TabIndex = 2;
-			// 
-			// label1
-			// 
-			this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			this.label1.AutoSize = true;
-			this.label1.Location = new System.Drawing.Point(7, 20);
-			this.label1.Name = "label1";
-			this.label1.Size = new System.Drawing.Size(195, 13);
-			this.label1.TabIndex = 5;
-			this.label1.Text = "Please verify that the location is correct.";
-			// 
-			// lblFoundTitle
-			// 
-			this.lblFoundTitle.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
-						| System.Windows.Forms.AnchorStyles.Right)));
-			this.lblFoundTitle.AutoSize = true;
-			this.m_fpdFontProvider.SetFontSet(this.lblFoundTitle, "GameSearchText");
-			this.m_fpdFontProvider.SetFontSize(this.lblFoundTitle, 12F);
-			this.m_fpdFontProvider.SetFontStyle(this.lblFoundTitle, System.Drawing.FontStyle.Italic);
-			this.lblFoundTitle.ForeColor = System.Drawing.Color.Green;
-			this.lblFoundTitle.Location = new System.Drawing.Point(6, 0);
-			this.lblFoundTitle.Name = "lblFoundTitle";
-			this.lblFoundTitle.Size = new System.Drawing.Size(59, 20);
-			this.lblFoundTitle.TabIndex = 4;
-			this.lblFoundTitle.Text = "Found!";
-			// 
-			// butReject
-			// 
-			this.butReject.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
-						| System.Windows.Forms.AnchorStyles.Right)));
-			this.butReject.AutoSize = true;
-			this.butReject.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.butReject.FlatAppearance.BorderSize = 0;
-			this.butReject.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.butReject.Image = global::Nexus.Client.Properties.Resources.dialog_cancel_4_16;
-			this.butReject.Location = new System.Drawing.Point(363, 3);
-			this.butReject.Name = "butReject";
-			this.butReject.Size = new System.Drawing.Size(22, 22);
-			this.butReject.TabIndex = 3;
-			this.butReject.UseVisualStyleBackColor = true;
-			this.butReject.Click += new System.EventHandler(this.butReject_Click);
-			// 
-			// butAccept
-			// 
-			this.butAccept.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
-						| System.Windows.Forms.AnchorStyles.Right)));
-			this.butAccept.AutoSize = true;
-			this.butAccept.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.butAccept.FlatAppearance.BorderSize = 0;
-			this.butAccept.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.butAccept.Image = global::Nexus.Client.Properties.Resources.dialog_ok_4_16;
-			this.butAccept.Location = new System.Drawing.Point(335, 3);
-			this.butAccept.Name = "butAccept";
-			this.butAccept.Size = new System.Drawing.Size(22, 22);
-			this.butAccept.TabIndex = 2;
-			this.butAccept.UseVisualStyleBackColor = true;
-			this.butAccept.Click += new System.EventHandler(this.butAccept_Click);
-			// 
-			// lblPath
-			// 
-			this.lblPath.AutoEllipsis = true;
-			this.m_fpdFontProvider.SetFontSet(this.lblPath, "StandardText");
-			this.m_fpdFontProvider.SetFontSize(this.lblPath, 10F);
-			this.lblPath.Location = new System.Drawing.Point(7, 33);
-			this.lblPath.Name = "lblPath";
-			this.lblPath.Size = new System.Drawing.Size(378, 33);
-			this.lblPath.TabIndex = 0;
-			this.lblPath.Text = "C:\\Program Files\\Interim Path\\Steam\\steamapps\\common\\Skyrim";
-			this.lblPath.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// pnlNotFound
-			// 
-			this.pnlNotFound.Controls.Add(this.butOverride);
-			this.pnlNotFound.Controls.Add(this.butSelectPath);
-			this.pnlNotFound.Controls.Add(this.tbxInstallPath);
-			this.pnlNotFound.Controls.Add(this.lblNotFoundMessage);
-			this.pnlNotFound.Controls.Add(this.lblNotFoundTitle);
-			this.pnlNotFound.Dock = System.Windows.Forms.DockStyle.Bottom;
-			this.pnlNotFound.Location = new System.Drawing.Point(128, 321);
-			this.pnlNotFound.Name = "pnlNotFound";
-			this.pnlNotFound.Size = new System.Drawing.Size(388, 66);
-			this.pnlNotFound.TabIndex = 3;
-			// 
-			// butOverride
-			// 
-			this.butOverride.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
-						| System.Windows.Forms.AnchorStyles.Right)));
-			this.butOverride.AutoSize = true;
-			this.butOverride.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.butOverride.Enabled = false;
-			this.butOverride.FlatAppearance.BorderSize = 0;
-			this.butOverride.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.butOverride.Image = global::Nexus.Client.Properties.Resources.dialog_ok_4_16;
-			this.butOverride.Location = new System.Drawing.Point(363, 6);
-			this.butOverride.Name = "butOverride";
-			this.butOverride.Size = new System.Drawing.Size(22, 22);
-			this.butOverride.TabIndex = 4;
-			this.butOverride.UseVisualStyleBackColor = true;
-			this.butOverride.Click += new System.EventHandler(this.butOverride_Click);
-			// 
-			// butSelectPath
-			// 
-			this.butSelectPath.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.butSelectPath.AutoSize = true;
-			this.butSelectPath.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.butSelectPath.Location = new System.Drawing.Point(339, 34);
-			this.butSelectPath.Name = "butSelectPath";
-			this.butSelectPath.Size = new System.Drawing.Size(26, 23);
-			this.butSelectPath.TabIndex = 3;
-			this.butSelectPath.Text = "...";
-			this.butSelectPath.UseVisualStyleBackColor = true;
-			this.butSelectPath.Click += new System.EventHandler(this.butSelectPath_Click);
-			// 
-			// tbxInstallPath
-			// 
-			this.tbxInstallPath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
-						| System.Windows.Forms.AnchorStyles.Right)));
-			this.tbxInstallPath.Location = new System.Drawing.Point(10, 36);
-			this.tbxInstallPath.Name = "tbxInstallPath";
-			this.tbxInstallPath.Size = new System.Drawing.Size(323, 20);
-			this.tbxInstallPath.TabIndex = 2;
-			this.tbxInstallPath.TextChanged += new System.EventHandler(this.tbxInstallPath_TextChanged);
-			// 
-			// lblNotFoundMessage
-			// 
-			this.lblNotFoundMessage.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			this.lblNotFoundMessage.AutoSize = true;
-			this.lblNotFoundMessage.Location = new System.Drawing.Point(7, 20);
-			this.lblNotFoundMessage.Name = "lblNotFoundMessage";
-			this.lblNotFoundMessage.Size = new System.Drawing.Size(200, 13);
-			this.lblNotFoundMessage.TabIndex = 1;
-			this.lblNotFoundMessage.Text = "If this is not correct, enter the game path:";
-			// 
-			// lblNotFoundTitle
-			// 
-			this.lblNotFoundTitle.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
-						| System.Windows.Forms.AnchorStyles.Right)));
-			this.lblNotFoundTitle.AutoSize = true;
-			this.m_fpdFontProvider.SetFontSet(this.lblNotFoundTitle, "GameSearchText");
-			this.m_fpdFontProvider.SetFontSize(this.lblNotFoundTitle, 12F);
-			this.m_fpdFontProvider.SetFontStyle(this.lblNotFoundTitle, System.Drawing.FontStyle.Italic);
-			this.lblNotFoundTitle.ForeColor = System.Drawing.Color.DarkRed;
-			this.lblNotFoundTitle.Location = new System.Drawing.Point(6, 0);
-			this.lblNotFoundTitle.Name = "lblNotFoundTitle";
-			this.lblNotFoundTitle.Size = new System.Drawing.Size(88, 20);
-			this.lblNotFoundTitle.TabIndex = 0;
-			this.lblNotFoundTitle.Text = "Not Found!";
-			// 
-			// fbdSelectPath
-			// 
-			this.fbdSelectPath.ShowNewFolderButton = false;
-			// 
-			// pbxGameLogo
-			// 
-			this.pbxGameLogo.Dock = System.Windows.Forms.DockStyle.Left;
-			this.pbxGameLogo.Location = new System.Drawing.Point(0, 0);
-			this.pbxGameLogo.Name = "pbxGameLogo";
-			this.pbxGameLogo.Size = new System.Drawing.Size(128, 519);
-			this.pbxGameLogo.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
-			this.pbxGameLogo.TabIndex = 0;
-			this.pbxGameLogo.TabStop = false;
-			// 
-			// erpErrors
-			// 
-			this.erpErrors.ContainerControl = this;
-			// 
-			// panel1
-			// 
-			this.panel1.Controls.Add(this.lblGameModeName);
-			this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.panel1.Location = new System.Drawing.Point(128, 0);
-			this.panel1.Name = "panel1";
-			this.panel1.Size = new System.Drawing.Size(388, 255);
-			this.panel1.TabIndex = 4;
-			// 
-			// pnlSearching
-			// 
-			this.pnlSearching.Controls.Add(this.butCancel);
-			this.pnlSearching.Controls.Add(this.pbrProgress);
-			this.pnlSearching.Controls.Add(this.lblSearchingTitle);
-			this.pnlSearching.Controls.Add(this.lblProgressMessage);
-			this.pnlSearching.Dock = System.Windows.Forms.DockStyle.Bottom;
-			this.pnlSearching.Location = new System.Drawing.Point(128, 387);
-			this.pnlSearching.Name = "pnlSearching";
-			this.pnlSearching.Size = new System.Drawing.Size(388, 66);
-			this.pnlSearching.TabIndex = 2;
-			// 
-			// butCancel
-			// 
-			this.butCancel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
-						| System.Windows.Forms.AnchorStyles.Right)));
-			this.butCancel.AutoSize = true;
-			this.butCancel.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.butCancel.FlatAppearance.BorderSize = 0;
-			this.butCancel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.butCancel.Image = global::Nexus.Client.Properties.Resources.dialog_cancel_4_16;
-			this.butCancel.Location = new System.Drawing.Point(363, 6);
-			this.butCancel.Name = "butCancel";
-			this.butCancel.Size = new System.Drawing.Size(22, 22);
-			this.butCancel.TabIndex = 6;
-			this.butCancel.UseVisualStyleBackColor = true;
-			this.butCancel.Click += new System.EventHandler(this.butCancel_Click);
-			// 
-			// pbrProgress
-			// 
-			this.pbrProgress.Location = new System.Drawing.Point(6, 36);
-			this.pbrProgress.Name = "pbrProgress";
-			this.pbrProgress.Size = new System.Drawing.Size(379, 23);
-			this.pbrProgress.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
-			this.pbrProgress.TabIndex = 5;
-			// 
-			// lblSearchingTitle
-			// 
-			this.lblSearchingTitle.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
-						| System.Windows.Forms.AnchorStyles.Right)));
-			this.lblSearchingTitle.AutoSize = true;
-			this.m_fpdFontProvider.SetFontSet(this.lblSearchingTitle, "GameSearchText");
-			this.m_fpdFontProvider.SetFontSize(this.lblSearchingTitle, 12F);
-			this.m_fpdFontProvider.SetFontStyle(this.lblSearchingTitle, System.Drawing.FontStyle.Italic);
-			this.lblSearchingTitle.ForeColor = System.Drawing.Color.Blue;
-			this.lblSearchingTitle.Location = new System.Drawing.Point(6, 0);
-			this.lblSearchingTitle.Name = "lblSearchingTitle";
-			this.lblSearchingTitle.Size = new System.Drawing.Size(89, 20);
-			this.lblSearchingTitle.TabIndex = 4;
-			this.lblSearchingTitle.Text = "Searching..";
-			// 
-			// lblProgressMessage
-			// 
-			this.lblProgressMessage.AutoEllipsis = true;
-			this.lblProgressMessage.Location = new System.Drawing.Point(7, 20);
-			this.lblProgressMessage.Name = "lblProgressMessage";
-			this.lblProgressMessage.Size = new System.Drawing.Size(358, 13);
-			this.lblProgressMessage.TabIndex = 1;
-			this.lblProgressMessage.Text = "label3";
-			// 
-			// pnlSet
-			// 
-			this.pnlSet.Controls.Add(this.lblFinalPath);
-			this.pnlSet.Dock = System.Windows.Forms.DockStyle.Bottom;
-			this.pnlSet.Location = new System.Drawing.Point(128, 255);
-			this.pnlSet.Name = "pnlSet";
-			this.pnlSet.Size = new System.Drawing.Size(388, 66);
-			this.pnlSet.TabIndex = 6;
-			// 
-			// lblFinalPath
-			// 
-			this.lblFinalPath.AutoEllipsis = true;
-			this.m_fpdFontProvider.SetFontSet(this.lblFinalPath, "StandardText");
-			this.m_fpdFontProvider.SetFontSize(this.lblFinalPath, 10F);
-			this.lblFinalPath.Location = new System.Drawing.Point(7, 3);
-			this.lblFinalPath.Name = "lblFinalPath";
-			this.lblFinalPath.Size = new System.Drawing.Size(378, 60);
-			this.lblFinalPath.TabIndex = 0;
-			this.lblFinalPath.Text = "C:\\Program Files\\Interim Path\\Steam\\steamapps\\common\\Skyrim";
-			this.lblFinalPath.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// GameModeSearchListViewItem
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.Controls.Add(this.panel1);
-			this.Controls.Add(this.pnlSet);
-			this.Controls.Add(this.pnlNotFound);
-			this.Controls.Add(this.pnlSearching);
-			this.Controls.Add(this.pnlCandidate);
-			this.Controls.Add(this.pbxGameLogo);
-			this.m_fpdFontProvider.SetFontSet(this, "StandardText");
-			this.MinimumSize = new System.Drawing.Size(516, 97);
-			this.Size = new System.Drawing.Size(516, 519);
-			this.pnlCandidate.ResumeLayout(false);
-			this.pnlCandidate.PerformLayout();
-			this.pnlNotFound.ResumeLayout(false);
-			this.pnlNotFound.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.pbxGameLogo)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.erpErrors)).EndInit();
-			this.panel1.ResumeLayout(false);
-			this.pnlSearching.ResumeLayout(false);
-			this.pnlSearching.PerformLayout();
-			this.pnlSet.ResumeLayout(false);
-			this.ResumeLayout(false);
+            this.components = new System.ComponentModel.Container();
+            this.fbdSelectPath = new System.Windows.Forms.FolderBrowserDialog();
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.lblGameModeName = new System.Windows.Forms.Label();
+            this.pnlSet = new System.Windows.Forms.Panel();
+            this.lblFinalPath = new Nexus.UI.Controls.PathLabel();
+            this.pnlNotFound = new System.Windows.Forms.Panel();
+            this.butOverride = new System.Windows.Forms.Button();
+            this.butSelectPath = new System.Windows.Forms.Button();
+            this.tbxInstallPath = new System.Windows.Forms.TextBox();
+            this.lblNotFoundMessage = new System.Windows.Forms.Label();
+            this.lblNotFoundTitle = new System.Windows.Forms.Label();
+            this.pnlSearching = new System.Windows.Forms.Panel();
+            this.butCancel = new System.Windows.Forms.Button();
+            this.pbrProgress = new System.Windows.Forms.ProgressBar();
+            this.lblSearchingTitle = new System.Windows.Forms.Label();
+            this.lblProgressMessage = new Nexus.UI.Controls.PathLabel();
+            this.pnlCandidate = new System.Windows.Forms.Panel();
+            this.label1 = new System.Windows.Forms.Label();
+            this.lblFoundTitle = new System.Windows.Forms.Label();
+            this.butReject = new System.Windows.Forms.Button();
+            this.butAccept = new System.Windows.Forms.Button();
+            this.lblPath = new Nexus.UI.Controls.PathLabel();
+            this.pbxGameLogo = new System.Windows.Forms.PictureBox();
+            this.erpErrors = new System.Windows.Forms.ErrorProvider(this.components);
+            this.pnlFileSystemError = new System.Windows.Forms.Panel();
+            this.lblFileSystemErrorDescription = new System.Windows.Forms.Label();
+            this.lblFileSystemError = new System.Windows.Forms.Label();
+            this.panel1.SuspendLayout();
+            this.pnlSet.SuspendLayout();
+            this.pnlNotFound.SuspendLayout();
+            this.pnlSearching.SuspendLayout();
+            this.pnlCandidate.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pbxGameLogo)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.erpErrors)).BeginInit();
+            this.pnlFileSystemError.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // fbdSelectPath
+            // 
+            this.fbdSelectPath.ShowNewFolderButton = false;
+            // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.pnlFileSystemError);
+            this.panel1.Controls.Add(this.lblGameModeName);
+            this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panel1.Location = new System.Drawing.Point(128, 0);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(388, 255);
+            this.panel1.TabIndex = 4;
+            // 
+            // lblGameModeName
+            // 
+            this.lblGameModeName.Dock = System.Windows.Forms.DockStyle.Top;
+            this.m_fpdFontProvider.SetFontSet(this.lblGameModeName, "HeadingText");
+            this.m_fpdFontProvider.SetFontSize(this.lblGameModeName, 20F);
+            this.m_fpdFontProvider.SetFontStyle(this.lblGameModeName, System.Drawing.FontStyle.Bold);
+            this.lblGameModeName.Location = new System.Drawing.Point(0, 0);
+            this.lblGameModeName.Name = "lblGameModeName";
+            this.lblGameModeName.Size = new System.Drawing.Size(388, 31);
+            this.lblGameModeName.TabIndex = 1;
+            this.lblGameModeName.Text = "GAME TITLE";
+            this.lblGameModeName.TextAlign = System.Drawing.ContentAlignment.BottomRight;
+            // 
+            // pnlSet
+            // 
+            this.pnlSet.Controls.Add(this.lblFinalPath);
+            this.pnlSet.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.pnlSet.Location = new System.Drawing.Point(128, 255);
+            this.pnlSet.Name = "pnlSet";
+            this.pnlSet.Size = new System.Drawing.Size(388, 66);
+            this.pnlSet.TabIndex = 6;
+            // 
+            // lblFinalPath
+            // 
+            this.lblFinalPath.AutoEllipsis = true;
+            this.m_fpdFontProvider.SetFontSet(this.lblFinalPath, "StandardText");
+            this.m_fpdFontProvider.SetFontSize(this.lblFinalPath, 10F);
+            this.lblFinalPath.Location = new System.Drawing.Point(7, 3);
+            this.lblFinalPath.Name = "lblFinalPath";
+            this.lblFinalPath.Size = new System.Drawing.Size(378, 60);
+            this.lblFinalPath.TabIndex = 0;
+            this.lblFinalPath.Text = "C:\\Program Files\\Interim Path\\Steam\\steamapps\\common\\Skyrim";
+            this.lblFinalPath.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // pnlNotFound
+            // 
+            this.pnlNotFound.Controls.Add(this.butOverride);
+            this.pnlNotFound.Controls.Add(this.butSelectPath);
+            this.pnlNotFound.Controls.Add(this.tbxInstallPath);
+            this.pnlNotFound.Controls.Add(this.lblNotFoundMessage);
+            this.pnlNotFound.Controls.Add(this.lblNotFoundTitle);
+            this.pnlNotFound.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.pnlNotFound.Location = new System.Drawing.Point(128, 321);
+            this.pnlNotFound.Name = "pnlNotFound";
+            this.pnlNotFound.Size = new System.Drawing.Size(388, 66);
+            this.pnlNotFound.TabIndex = 3;
+            // 
+            // butOverride
+            // 
+            this.butOverride.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.butOverride.AutoSize = true;
+            this.butOverride.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.butOverride.Enabled = false;
+            this.butOverride.FlatAppearance.BorderSize = 0;
+            this.butOverride.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.butOverride.Image = global::Nexus.Client.Properties.Resources.dialog_ok_4_16;
+            this.butOverride.Location = new System.Drawing.Point(363, 6);
+            this.butOverride.Name = "butOverride";
+            this.butOverride.Size = new System.Drawing.Size(22, 22);
+            this.butOverride.TabIndex = 4;
+            this.butOverride.UseVisualStyleBackColor = true;
+            this.butOverride.Click += new System.EventHandler(this.butOverride_Click);
+            // 
+            // butSelectPath
+            // 
+            this.butSelectPath.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.butSelectPath.AutoSize = true;
+            this.butSelectPath.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.butSelectPath.Location = new System.Drawing.Point(339, 34);
+            this.butSelectPath.Name = "butSelectPath";
+            this.butSelectPath.Size = new System.Drawing.Size(26, 23);
+            this.butSelectPath.TabIndex = 3;
+            this.butSelectPath.Text = "...";
+            this.butSelectPath.UseVisualStyleBackColor = true;
+            this.butSelectPath.Click += new System.EventHandler(this.butSelectPath_Click);
+            // 
+            // tbxInstallPath
+            // 
+            this.tbxInstallPath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.tbxInstallPath.Location = new System.Drawing.Point(10, 36);
+            this.tbxInstallPath.Name = "tbxInstallPath";
+            this.tbxInstallPath.Size = new System.Drawing.Size(323, 20);
+            this.tbxInstallPath.TabIndex = 2;
+            this.tbxInstallPath.TextChanged += new System.EventHandler(this.tbxInstallPath_TextChanged);
+            // 
+            // lblNotFoundMessage
+            // 
+            this.lblNotFoundMessage.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.lblNotFoundMessage.AutoSize = true;
+            this.lblNotFoundMessage.Location = new System.Drawing.Point(7, 20);
+            this.lblNotFoundMessage.Name = "lblNotFoundMessage";
+            this.lblNotFoundMessage.Size = new System.Drawing.Size(200, 13);
+            this.lblNotFoundMessage.TabIndex = 1;
+            this.lblNotFoundMessage.Text = "If this is not correct, enter the game path:";
+            // 
+            // lblNotFoundTitle
+            // 
+            this.lblNotFoundTitle.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblNotFoundTitle.AutoSize = true;
+            this.m_fpdFontProvider.SetFontSet(this.lblNotFoundTitle, "GameSearchText");
+            this.m_fpdFontProvider.SetFontSize(this.lblNotFoundTitle, 12F);
+            this.m_fpdFontProvider.SetFontStyle(this.lblNotFoundTitle, System.Drawing.FontStyle.Italic);
+            this.lblNotFoundTitle.ForeColor = System.Drawing.Color.DarkRed;
+            this.lblNotFoundTitle.Location = new System.Drawing.Point(6, 0);
+            this.lblNotFoundTitle.Name = "lblNotFoundTitle";
+            this.lblNotFoundTitle.Size = new System.Drawing.Size(88, 20);
+            this.lblNotFoundTitle.TabIndex = 0;
+            this.lblNotFoundTitle.Text = "Not Found!";
+            // 
+            // pnlSearching
+            // 
+            this.pnlSearching.Controls.Add(this.butCancel);
+            this.pnlSearching.Controls.Add(this.pbrProgress);
+            this.pnlSearching.Controls.Add(this.lblSearchingTitle);
+            this.pnlSearching.Controls.Add(this.lblProgressMessage);
+            this.pnlSearching.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.pnlSearching.Location = new System.Drawing.Point(128, 387);
+            this.pnlSearching.Name = "pnlSearching";
+            this.pnlSearching.Size = new System.Drawing.Size(388, 66);
+            this.pnlSearching.TabIndex = 2;
+            // 
+            // butCancel
+            // 
+            this.butCancel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.butCancel.AutoSize = true;
+            this.butCancel.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.butCancel.FlatAppearance.BorderSize = 0;
+            this.butCancel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.butCancel.Image = global::Nexus.Client.Properties.Resources.dialog_cancel_4_16;
+            this.butCancel.Location = new System.Drawing.Point(363, 6);
+            this.butCancel.Name = "butCancel";
+            this.butCancel.Size = new System.Drawing.Size(22, 22);
+            this.butCancel.TabIndex = 6;
+            this.butCancel.UseVisualStyleBackColor = true;
+            this.butCancel.Click += new System.EventHandler(this.butCancel_Click);
+            // 
+            // pbrProgress
+            // 
+            this.pbrProgress.Location = new System.Drawing.Point(6, 36);
+            this.pbrProgress.Name = "pbrProgress";
+            this.pbrProgress.Size = new System.Drawing.Size(379, 23);
+            this.pbrProgress.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
+            this.pbrProgress.TabIndex = 5;
+            // 
+            // lblSearchingTitle
+            // 
+            this.lblSearchingTitle.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblSearchingTitle.AutoSize = true;
+            this.m_fpdFontProvider.SetFontSet(this.lblSearchingTitle, "GameSearchText");
+            this.m_fpdFontProvider.SetFontSize(this.lblSearchingTitle, 12F);
+            this.m_fpdFontProvider.SetFontStyle(this.lblSearchingTitle, System.Drawing.FontStyle.Italic);
+            this.lblSearchingTitle.ForeColor = System.Drawing.Color.Blue;
+            this.lblSearchingTitle.Location = new System.Drawing.Point(6, 0);
+            this.lblSearchingTitle.Name = "lblSearchingTitle";
+            this.lblSearchingTitle.Size = new System.Drawing.Size(89, 20);
+            this.lblSearchingTitle.TabIndex = 4;
+            this.lblSearchingTitle.Text = "Searching..";
+            // 
+            // lblProgressMessage
+            // 
+            this.lblProgressMessage.AutoEllipsis = true;
+            this.lblProgressMessage.Location = new System.Drawing.Point(7, 20);
+            this.lblProgressMessage.Name = "lblProgressMessage";
+            this.lblProgressMessage.Size = new System.Drawing.Size(358, 13);
+            this.lblProgressMessage.TabIndex = 1;
+            this.lblProgressMessage.Text = "label3";
+            // 
+            // pnlCandidate
+            // 
+            this.pnlCandidate.Controls.Add(this.label1);
+            this.pnlCandidate.Controls.Add(this.lblFoundTitle);
+            this.pnlCandidate.Controls.Add(this.butReject);
+            this.pnlCandidate.Controls.Add(this.butAccept);
+            this.pnlCandidate.Controls.Add(this.lblPath);
+            this.pnlCandidate.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.pnlCandidate.Location = new System.Drawing.Point(128, 453);
+            this.pnlCandidate.Name = "pnlCandidate";
+            this.pnlCandidate.Size = new System.Drawing.Size(388, 66);
+            this.pnlCandidate.TabIndex = 2;
+            // 
+            // label1
+            // 
+            this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(7, 20);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(195, 13);
+            this.label1.TabIndex = 5;
+            this.label1.Text = "Please verify that the location is correct.";
+            // 
+            // lblFoundTitle
+            // 
+            this.lblFoundTitle.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblFoundTitle.AutoSize = true;
+            this.m_fpdFontProvider.SetFontSet(this.lblFoundTitle, "GameSearchText");
+            this.m_fpdFontProvider.SetFontSize(this.lblFoundTitle, 12F);
+            this.m_fpdFontProvider.SetFontStyle(this.lblFoundTitle, System.Drawing.FontStyle.Italic);
+            this.lblFoundTitle.ForeColor = System.Drawing.Color.Green;
+            this.lblFoundTitle.Location = new System.Drawing.Point(6, 0);
+            this.lblFoundTitle.Name = "lblFoundTitle";
+            this.lblFoundTitle.Size = new System.Drawing.Size(59, 20);
+            this.lblFoundTitle.TabIndex = 4;
+            this.lblFoundTitle.Text = "Found!";
+            // 
+            // butReject
+            // 
+            this.butReject.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.butReject.AutoSize = true;
+            this.butReject.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.butReject.FlatAppearance.BorderSize = 0;
+            this.butReject.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.butReject.Image = global::Nexus.Client.Properties.Resources.dialog_cancel_4_16;
+            this.butReject.Location = new System.Drawing.Point(363, 3);
+            this.butReject.Name = "butReject";
+            this.butReject.Size = new System.Drawing.Size(22, 22);
+            this.butReject.TabIndex = 3;
+            this.butReject.UseVisualStyleBackColor = true;
+            this.butReject.Click += new System.EventHandler(this.butReject_Click);
+            // 
+            // butAccept
+            // 
+            this.butAccept.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.butAccept.AutoSize = true;
+            this.butAccept.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.butAccept.FlatAppearance.BorderSize = 0;
+            this.butAccept.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.butAccept.Image = global::Nexus.Client.Properties.Resources.dialog_ok_4_16;
+            this.butAccept.Location = new System.Drawing.Point(335, 3);
+            this.butAccept.Name = "butAccept";
+            this.butAccept.Size = new System.Drawing.Size(22, 22);
+            this.butAccept.TabIndex = 2;
+            this.butAccept.UseVisualStyleBackColor = true;
+            this.butAccept.Click += new System.EventHandler(this.butAccept_Click);
+            // 
+            // lblPath
+            // 
+            this.lblPath.AutoEllipsis = true;
+            this.m_fpdFontProvider.SetFontSet(this.lblPath, "StandardText");
+            this.m_fpdFontProvider.SetFontSize(this.lblPath, 10F);
+            this.lblPath.Location = new System.Drawing.Point(7, 33);
+            this.lblPath.Name = "lblPath";
+            this.lblPath.Size = new System.Drawing.Size(378, 33);
+            this.lblPath.TabIndex = 0;
+            this.lblPath.Text = "C:\\Program Files\\Interim Path\\Steam\\steamapps\\common\\Skyrim";
+            this.lblPath.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // pbxGameLogo
+            // 
+            this.pbxGameLogo.Dock = System.Windows.Forms.DockStyle.Left;
+            this.pbxGameLogo.Location = new System.Drawing.Point(0, 0);
+            this.pbxGameLogo.Name = "pbxGameLogo";
+            this.pbxGameLogo.Size = new System.Drawing.Size(128, 519);
+            this.pbxGameLogo.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
+            this.pbxGameLogo.TabIndex = 0;
+            this.pbxGameLogo.TabStop = false;
+            // 
+            // erpErrors
+            // 
+            this.erpErrors.ContainerControl = this;
+            // 
+            // pnlFileSystemError
+            // 
+            this.pnlFileSystemError.Controls.Add(this.lblFileSystemErrorDescription);
+            this.pnlFileSystemError.Controls.Add(this.lblFileSystemError);
+            this.pnlFileSystemError.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.pnlFileSystemError.Location = new System.Drawing.Point(0, 189);
+            this.pnlFileSystemError.Name = "pnlFileSystemError";
+            this.pnlFileSystemError.Size = new System.Drawing.Size(388, 66);
+            this.pnlFileSystemError.TabIndex = 4;
+            // 
+            // lblFileSystemErrorDescription
+            // 
+            this.lblFileSystemErrorDescription.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.lblFileSystemErrorDescription.AutoSize = true;
+            this.lblFileSystemErrorDescription.Location = new System.Drawing.Point(6, 20);
+            this.lblFileSystemErrorDescription.Name = "lblFileSystemErrorDescription";
+            this.lblFileSystemErrorDescription.Size = new System.Drawing.Size(299, 13);
+            this.lblFileSystemErrorDescription.TabIndex = 1;
+            this.lblFileSystemErrorDescription.Text = "This game is installed on a drive with an unsuitable file system.";
+            // 
+            // lblFileSystemError
+            // 
+            this.lblFileSystemError.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblFileSystemError.AutoSize = true;
+            this.m_fpdFontProvider.SetFontSet(this.lblFileSystemError, "GameSearchText");
+            this.m_fpdFontProvider.SetFontSize(this.lblFileSystemError, 12F);
+            this.m_fpdFontProvider.SetFontStyle(this.lblFileSystemError, System.Drawing.FontStyle.Italic);
+            this.lblFileSystemError.ForeColor = System.Drawing.Color.DarkRed;
+            this.lblFileSystemError.Location = new System.Drawing.Point(6, 0);
+            this.lblFileSystemError.Name = "lblFileSystemError";
+            this.lblFileSystemError.Size = new System.Drawing.Size(163, 20);
+            this.lblFileSystemError.TabIndex = 0;
+            this.lblFileSystemError.Text = "Unsuitable file system";
+            // 
+            // GameModeSearchListViewItem
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.panel1);
+            this.Controls.Add(this.pnlSet);
+            this.Controls.Add(this.pnlNotFound);
+            this.Controls.Add(this.pnlSearching);
+            this.Controls.Add(this.pnlCandidate);
+            this.Controls.Add(this.pbxGameLogo);
+            this.m_fpdFontProvider.SetFontSet(this, "StandardText");
+            this.MinimumSize = new System.Drawing.Size(516, 97);
+            this.Size = new System.Drawing.Size(516, 519);
+            this.panel1.ResumeLayout(false);
+            this.pnlSet.ResumeLayout(false);
+            this.pnlNotFound.ResumeLayout(false);
+            this.pnlNotFound.PerformLayout();
+            this.pnlSearching.ResumeLayout(false);
+            this.pnlSearching.PerformLayout();
+            this.pnlCandidate.ResumeLayout(false);
+            this.pnlCandidate.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pbxGameLogo)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.erpErrors)).EndInit();
+            this.pnlFileSystemError.ResumeLayout(false);
+            this.pnlFileSystemError.PerformLayout();
+            this.ResumeLayout(false);
 
 		}
 
@@ -396,5 +438,8 @@
 		private System.Windows.Forms.Panel pnlSet;
 		private Nexus.UI.Controls.PathLabel lblFinalPath;
 		private System.Windows.Forms.Button butCancel;
-	}
+        private System.Windows.Forms.Panel pnlFileSystemError;
+        private System.Windows.Forms.Label lblFileSystemErrorDescription;
+        private System.Windows.Forms.Label lblFileSystemError;
+    }
 }

--- a/NexusClient/UI/Controls/GameModeSearchListViewItem.cs
+++ b/NexusClient/UI/Controls/GameModeSearchListViewItem.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Drawing;
-using System.Drawing.Text;
-using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using Nexus.Client.BackgroundTasks;
 using Nexus.Client.Games;
@@ -99,11 +97,21 @@ namespace Nexus.Client.UI.Controls
 				Invoke((Action<object, GameModeDiscoveredEventArgs>)Detector_PathFound, sender, e);
 				return;
 			}
+
 			if (e.GameMode.ModeId.Equals(GameMode.ModeId))
 			{
 				m_booGamePathDetected = true;
-				lblPath.Text = e.InstallationPath;
-				SetVisiblePanel(pnlCandidate);
+                m_booAcceptedPath = e.InstalledOnSuitableFileSystem;
+                lblPath.Text = e.InstallationPath;
+
+                if (e.InstalledOnSuitableFileSystem)
+                {
+                    SetVisiblePanel(pnlCandidate);
+                }
+                else
+                {
+                    SetVisiblePanel(pnlFileSystemError);
+                }
 			}
 		}
 

--- a/Util/FileUtil.cs
+++ b/Util/FileUtil.cs
@@ -355,17 +355,45 @@ namespace Nexus.Client.Util
 			return p_strPath.Trim(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar).EndsWith(Path.VolumeSeparatorChar.ToString(), StringComparison.OrdinalIgnoreCase);
 		}
 
-		/// <summary>
-		/// Writes the given data to the specified file.
-		/// </summary>
-		/// <remarks>
-		/// If the specified file exists, it will be overwritten. If the specified file
-		/// does not exist, it is created. If the directory containing the specified file
-		/// does not exist, it is created.
-		/// </remarks>
-		/// <param name="p_strPath">The path to which to write the given data.</param>
-		/// <param name="p_bteData">The data to write to the file.</param>
-		public static void WriteAllBytes(string p_strPath, byte[] p_bteData)
+        /// <summary>
+        /// Determines if the file system of the drive is suitable for NMM to use.
+        /// </summary>
+        /// <param name="p_strPath">Path to folder on drive we want to check.</param>
+        /// <returns>True if we expect NMM to be able to use the drive in question, otherwise false.</returns>
+        public static bool DoesFileSystemSupportSymbolicLinks(string p_strPath)
+        {
+            if (string.IsNullOrEmpty(p_strPath))
+            {
+                // Won't matter if there's no path.
+                return true;
+            }
+
+            // This list can be extended as needed, and is not case sensitive.
+            var knownBadFileSystems = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "FAT",
+                "FAT32",
+                "ReFS",
+                "exFAT"
+            };
+
+            var file = new FileInfo(p_strPath);
+            var drive = new DriveInfo(file.Directory.Root.FullName);
+
+            return !knownBadFileSystems.Contains(drive.DriveFormat);
+        }
+
+        /// <summary>
+        /// Writes the given data to the specified file.
+        /// </summary>
+        /// <remarks>
+        /// If the specified file exists, it will be overwritten. If the specified file
+        /// does not exist, it is created. If the directory containing the specified file
+        /// does not exist, it is created.
+        /// </remarks>
+        /// <param name="p_strPath">The path to which to write the given data.</param>
+        /// <param name="p_bteData">The data to write to the file.</param>
+        public static void WriteAllBytes(string p_strPath, byte[] p_bteData)
 		{
 			string strDirectory = Path.GetDirectoryName(p_strPath);
 			if (!Directory.Exists(strDirectory))


### PR DESCRIPTION
This is intended as a "fix" for #19 and #131 , which will block the user from enabling a game in NMM if it's installed on an unsupported file system. 

During game discovery NMM will now determine what file system the drive the game is installed on has, and check against a defined list of incompatible systems. If an incompatible file system is detected, the following message will be shown and the user will not be able to enable that game mode:

>![image](https://user-images.githubusercontent.com/864820/40273309-319bfa3e-5bbe-11e8-9fbc-23e2b4887353.png)

The file systems currently deemed unfit (based on #19 and #131) are:
- FAT
- FAT32
- ReFS
- exFAT

Arguably you could allow the user some other option, like selecting another path - but it seems unlikely that a user has the same game installed on two different drives at the same time.