### PR TITLE
Suggested fix for crash in #341

### DIFF
--- a/Util/Downloader/CompletedDownloadEventArgs.cs
+++ b/Util/Downloader/CompletedDownloadEventArgs.cs
@@ -21,6 +21,11 @@ namespace Nexus.Client.Util.Downloader
 		/// <value>The path to the downloaded file.</value>
 		public string SavedFileName { get; private set; }
 
+        /// <summary>
+        /// Gets the failure message, if the download didn't succeed.
+        /// </summary>
+        public string FailureMessage { get; private set; }
+
 		#endregion
 
 		#region Constructors
@@ -34,7 +39,21 @@ namespace Nexus.Client.Util.Downloader
 		{
 			GotEntireFile = p_booGetEntireFile;
 			SavedFileName = p_strSavedFileName;
+            FailureMessage = string.Empty;
 		}
+
+        /// <summary>
+		/// A simple constructor that initializes the object with the given values.
+		/// </summary>
+		/// <param name="p_booGetEntireFile">Whether the entire file has been downloaded.</param>
+		/// <param name="p_strSavedFileName">The path to the downloaded file.</param>
+        /// <param name="p_strFailureMessage">Failure message, if download did not succeed.</param>
+        public CompletedDownloadEventArgs(bool p_booGetEntireFile, string p_strSavedFileName, string p_strFailureMessage)
+        {
+            GotEntireFile = p_booGetEntireFile;
+            SavedFileName = p_strSavedFileName;
+            FailureMessage = p_strFailureMessage;
+        }
 
 		#endregion
 	}


### PR DESCRIPTION
#341 exposes a crash when an antivirus removes the downloaded file before NMM can use it, this will handle that case and show an error message and failing the download.

> ![image](https://user-images.githubusercontent.com/864820/40516851-e256f0d4-5fb2-11e8-9e0b-0a232c001a63.png)

Issue can (right now) be reproduced by downloading the [BodySlide and Outfit Studio](https://www.nexusmods.com/fallout4/mods/25) mod - unclear whether the file is infected or just a false positive...

For reviewers: Sorry, VS did a lot of changing tabs to spaces and adding curly brackets here and there.