### PR TITLE
Suggestion: Use GitHub releases for automatic updater

### DIFF
--- a/NexusClient/NexusClient.csproj
+++ b/NexusClient/NexusClient.csproj
@@ -349,6 +349,7 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="UI\Controls\ProfilesListView.designer.cs" />
+    <Compile Include="Updating\GitHubRelease.cs" />
     <Compile Include="Util\NexusFileUtil.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/NexusClient/Updating/GitHubRelease.cs
+++ b/NexusClient/Updating/GitHubRelease.cs
@@ -62,15 +62,29 @@
         
         private static Version ParseVersion(string content)
         {
-            var releaseVersion = Regex.Match(content, "tag_name\":\"(\\d+\\.\\d+\\.\\d)\"", RegexOptions.IgnoreCase).Groups[1];
-            var tmp = releaseVersion.Value.Split('.');
+            try
+            {
+                var releaseVersion = Regex.Match(content, "tag_name\":\"(\\d+\\.\\d+\\.\\d)\"", RegexOptions.IgnoreCase).Groups[1];
+                var tmp = releaseVersion.Value.Split('.');
 
-            return new Version(Convert.ToInt32(tmp[0]), Convert.ToInt32(tmp[1]), Convert.ToInt32(tmp[2]));
+                return new Version(Convert.ToInt32(tmp[0]), Convert.ToInt32(tmp[1]), Convert.ToInt32(tmp[2]));
+            }
+            catch
+            {
+                return new Version(69, 69, 69, 69);
+            }
         }
 
         private static string ParseDownloadLink(string content)
         {
-            return Regex.Match(content, "browser_download_url\":\"(.*\\.exe)\"", RegexOptions.IgnoreCase).Groups[1].Value;
+            try
+            {
+                return Regex.Match(content, "browser_download_url\":\"(.*\\.exe)\"", RegexOptions.IgnoreCase).Groups[1].Value;
+            }
+            catch
+            {
+                return string.Empty;
+            }
         }
     }
 }

--- a/NexusClient/Updating/GitHubRelease.cs
+++ b/NexusClient/Updating/GitHubRelease.cs
@@ -1,0 +1,76 @@
+﻿namespace Nexus.Client.Updating
+{
+    using System;
+    using System.Diagnostics;
+    using System.Net;
+    using System.Text.RegularExpressions;
+
+    /// <summary>
+    /// Represents information about a GitHub release.
+    /// </summary>
+    public class GitHubRelease
+    {
+        /// <summary>
+        /// Creates a GitHubRelease object with information from given API call.
+        /// </summary>
+        /// <param name="apiCall">API call to make for this GitHub release.</param>
+        public GitHubRelease(string apiCall)
+        {
+            try
+            {
+                using (var wc = new WebClient())
+                {
+                    wc.Headers.Add("User-Agent", "N/A");
+                    var content = wc.DownloadString(apiCall);
+
+                    Version = ParseVersion(content);
+                    DownloadLink = ParseDownloadLink(content);
+                }
+            }
+            catch (WebException e)
+            {
+                Trace.TraceError("Could not get version information: {0}", e.Message);
+                Version = new Version(69, 69, 69, 69);
+                DownloadLink = string.Empty;
+            }
+        }
+
+        #region Properties
+
+        /// <summary>
+        /// Link to information about the latest release on GitHub.
+        /// </summary>
+        public static string LatestRelease
+        {
+            get
+            {
+                return "https://api.github.com/repos/Nexus-Mods/Nexus-Mod-Manager/releases/latest";
+            }
+        }
+
+        /// <summary>
+        /// Version of the latest release.
+        /// </summary>
+        public Version Version { get; private set; }
+
+        /// <summary>
+        /// URL to the installer file of the latest release.
+        /// </summary>
+        public string DownloadLink { get; private set; }
+
+        #endregion
+        
+        private static Version ParseVersion(string content)
+        {
+            var releaseVersion = Regex.Match(content, "tag_name\":\"(\\d+\\.\\d+\\.\\d)\"", RegexOptions.IgnoreCase).Groups[1];
+            var tmp = releaseVersion.Value.Split('.');
+
+            return new Version(Convert.ToInt32(tmp[0]), Convert.ToInt32(tmp[1]), Convert.ToInt32(tmp[2]));
+        }
+
+        private static string ParseDownloadLink(string content)
+        {
+            return Regex.Match(content, "browser_download_url\":\"(.*\\.exe)\"", RegexOptions.IgnoreCase).Groups[1].Value;
+        }
+    }
+}


### PR DESCRIPTION
It's possible to read version information and get download links from the GitHub releases page of NMM, as this PR demonstrates. The one thing I see that could mess this up is if a release was created with a tag other than an expected `x.y.z` version number format.

To try it out you can build an installer locally, with a faked version number below 0.65.5, and it'll grab 0.65.5 from GitHub for you.

For release notes I simply pointed to the Releases page.