### PR TITLE
+ update ProgrammeUpdater::ExtendedWebClient to properly access legac…

### DIFF
--- a/NexusClient/ModRepositories/Nexus/NexusLinks.cs
+++ b/NexusClient/ModRepositories/Nexus/NexusLinks.cs
@@ -48,7 +48,7 @@ namespace Nexus.Client.ModRepositories.Nexus
 		{
 			get
 			{
-				return @"https://api.github.com/repos/Nexus-Mods/Nexus-Mod-Manager/releases";
+				return @"https://api.github.com/repos/Nexus-Mods/Nexus-Mod-Manager/releases/latest";
 			}
 		}
 

--- a/NexusClient/ModRepositories/Nexus/NexusLinks.cs
+++ b/NexusClient/ModRepositories/Nexus/NexusLinks.cs
@@ -52,15 +52,7 @@ namespace Nexus.Client.ModRepositories.Nexus
 			}
 		}
 
-		public static string LatestVersion4dot5
-		{
-			get
-			{
-				return @"https://dev.nexusmods.com/client/4.5/latestversion.php";
-			}
-		}
-
-		public static string Releases
+		public static string GithubReleases
 		{
 			get
 			{

--- a/NexusClient/ModRepositories/Nexus/NexusLinks.cs
+++ b/NexusClient/ModRepositories/Nexus/NexusLinks.cs
@@ -52,7 +52,7 @@ namespace Nexus.Client.ModRepositories.Nexus
 			}
 		}
 
-		public static string GithubReleases
+		public static string Releases
 		{
 			get
 			{

--- a/NexusClient/ModRepositories/Nexus/NexusLinks.cs
+++ b/NexusClient/ModRepositories/Nexus/NexusLinks.cs
@@ -48,7 +48,7 @@ namespace Nexus.Client.ModRepositories.Nexus
 		{
 			get
 			{
-				return @"https://legacy-api.nexusmods.com/NMM?GetLatestVersion";
+				return @"https://api.github.com/repos/Nexus-Mods/Nexus-Mod-Manager/releases";
 			}
 		}
 

--- a/NexusClient/Updating/ProgrammeUpdater.cs
+++ b/NexusClient/Updating/ProgrammeUpdater.cs
@@ -219,28 +219,24 @@ namespace Nexus.Client.Updating
                 bool ret = false;
                 try
                 {
-                    List<GitHubReleaseJsonContract> ghrjc = JSONSerializer.Deserialize<List<GitHubReleaseJsonContract>>(data);
-                    if (ghrjc != null && ghrjc.Count > 0)
+                    GitHubReleaseJsonContract ghrjc = JSONSerializer.Deserialize<GitHubReleaseJsonContract>(data);
+                    if (ghrjc != null)
                     {
-                        GitHubReleaseJsonContract latest = ghrjc[0];
-						if (latest != null)
-						{
-							if (!string.IsNullOrEmpty(latest.tag_name))
-							{
-								this.LatestVersion = latest.tag_name;
-							}
-							if (latest.assets_info != null)
-							{
-								if (latest.assets_info[0] != null)
-								{
-									if (!string.IsNullOrEmpty(latest.assets_info[0].browser_download_url))
-									{
-                                        this.LatestVersionUrl = latest.assets_info[0].browser_download_url;
-									}
-								}
-							}
-							ret = ( (this.LatestVersion != "") && (this.LatestVersionUrl != "") );
-                        }
+                        if (!string.IsNullOrEmpty(ghrjc.tag_name))
+                            {
+                                this.LatestVersion = ghrjc.tag_name;
+                            }
+                            if (ghrjc.assets_info != null)
+                            {
+                                if (ghrjc.assets_info[0] != null)
+                                {
+                                    if (!string.IsNullOrEmpty(ghrjc.assets_info[0].browser_download_url))
+                                    {
+                                        this.LatestVersionUrl = ghrjc.assets_info[0].browser_download_url;
+                                    }
+                                }
+                            }
+                            ret = ( (this.LatestVersion != "") && (this.LatestVersionUrl != "") );
                     }
                 }
                 catch (Exception e)

--- a/NexusClient/Updating/ProgrammeUpdater.cs
+++ b/NexusClient/Updating/ProgrammeUpdater.cs
@@ -223,9 +223,24 @@ namespace Nexus.Client.Updating
                     if (ghrjc != null && ghrjc.Count > 0)
                     {
                         GitHubReleaseJsonContract latest = ghrjc[0];
-                        this.LatestVersion = latest.tag_name;
-                        this.LatestVersionUrl = latest.assets_info[0].browser_download_url;
-                        ret = true;
+						if (latest != null)
+						{
+							if (!string.IsNullOrEmpty(latest.tag_name))
+							{
+								this.LatestVersion = latest.tag_name;
+							}
+							if (latest.assets_info != null)
+							{
+								if (latest.assets_info[0] != null)
+								{
+									if (!string.IsNullOrEmpty(latest.assets_info[0].browser_download_url))
+									{
+                                        this.LatestVersionUrl = latest.assets_info[0].browser_download_url);
+									}
+								}
+							}
+							ret = ( (this.LatestVersion != "") && (this.LatestVersionUrl != "") );
+                        }
                     }
                 }
                 catch (Exception e)

--- a/NexusClient/Updating/ProgrammeUpdater.cs
+++ b/NexusClient/Updating/ProgrammeUpdater.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
@@ -38,6 +38,8 @@ namespace Nexus.Client.Updating
 			public ExtendedWebClient(int p_intTimeout)
 			{
 				this.m_intDefaultTimeout = p_intTimeout;
+				this.Headers["User-Agent"] = string.Format("Nexus Client v{0}", ProgrammeMetadata.VersionString);
+		                this.Headers["Accept"] = "text/html,application/json,application/xml,application/xhtml+xml";
 			}
 
 			protected override WebRequest GetWebRequest(Uri uri)
@@ -370,10 +372,13 @@ namespace Nexus.Client.Updating
 			try
 			{
 				string strNewVersion = wclNewVersion.DownloadString(NexusLinks.LatestVersion);
+				strNewVersion = strNewVersion.TrimStart(new char[] { '\"' });
+				strNewVersion = strNewVersion.TrimEnd(new char[] { '\"' });
 				if (!String.IsNullOrEmpty(strNewVersion))
 				{
 					verNew = new Version(strNewVersion.Split('|')[0]);
 					p_strDownloadUri = strNewVersion.Split('|')[1];
+					p_strDownloadUri = p_strDownloadUri.Replace(@"\/", @"/");
 				}
 			}
 			catch (WebException)
@@ -381,10 +386,13 @@ namespace Nexus.Client.Updating
 				try
 				{
 					string strNewVersion = wclNewVersion.DownloadString(NexusLinks.LatestVersion4dot5);
+					strNewVersion = strNewVersion.TrimStart(new char[] { '\"' });
+			                strNewVersion = strNewVersion.TrimEnd(new char[] { '\"' });
 					if (!String.IsNullOrEmpty(strNewVersion))
 					{
 						verNew = new Version(strNewVersion.Split('|')[0]);
 						p_strDownloadUri = strNewVersion.Split('|')[1];
+						p_strDownloadUri = p_strDownloadUri.Replace(@"\/", @"/");
 					}
 				}
 				catch (WebException e)

--- a/NexusClient/Updating/ProgrammeUpdater.cs
+++ b/NexusClient/Updating/ProgrammeUpdater.cs
@@ -447,7 +447,7 @@ namespace Nexus.Client.Updating
                     stbAVMessage.AppendLine("As a result you won't be able to automatically update the program.");
                     stbAVMessage.AppendLine();
                     stbAVMessage.AppendFormat("You can download the update manually from:");
-                    stbAVMessage.AppendLine(NexusLinks.GithubReleases);
+                    stbAVMessage.AppendLine(NexusLinks.Releases);
                     try
                     {
                         //the extended message box contains an activex control wich must be run in an STA thread,
@@ -501,7 +501,7 @@ namespace Nexus.Client.Updating
                         stbAVMessage.AppendLine();
                         stbAVMessage.AppendFormat("To fix this issue you need to add {0}'s executable and all its folders to your", EnvironmentInfo.Settings.ModManagerName).AppendLine();
                         stbAVMessage.AppendLine("anti-virus exception list. You can also download the update manually from:");
-                        stbAVMessage.AppendLine(NexusLinks.GithubReleases);
+                        stbAVMessage.AppendLine(NexusLinks.Releases);
 
                         try
                         {
@@ -542,7 +542,7 @@ namespace Nexus.Client.Updating
                 stbPromptMessage.AppendLine();
                 stbPromptMessage.AppendLine();
                 stbPromptMessage.AppendLine("NOTE: You can find the release notes and past versions here:");
-                stbPromptMessage.AppendLine(NexusLinks.GithubReleases);
+                stbPromptMessage.AppendLine(NexusLinks.Releases);
 
                 try
                 {

--- a/NexusClient/Updating/ProgrammeUpdater.cs
+++ b/NexusClient/Updating/ProgrammeUpdater.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Threading;
 using System.Windows.Forms;
@@ -11,405 +13,612 @@ using Nexus.UI.Controls;
 
 namespace Nexus.Client.Updating
 {
-	/// <summary>
-	/// Updates the programme.
-	/// </summary>
-	public class ProgrammeUpdater : UpdaterBase
-	{
 
-		private class ExtendedWebClient : WebClient
-		{
-			private int m_intDefaultTimeout = 30000;
+    /// <summary>
+    /// Updates the programme.
+    /// </summary>
+    public class ProgrammeUpdater : UpdaterBase
+    {
+    
+        #region  GitHubReleaseJsonContract
+        /* These classes (contracts) should be based on the format of the json from:
+            https://api.github.com/repos/Nexus-Mods/Nexus-Mod-Manager/releases
+        */
+        [DataContract]
+        private class GitHubReleaseJsonContract
+        {
+            [DataMember(Name = "url")]
+            public string url { get; set; }
+            [DataMember(Name = "assets_url")]
+            public string assets_url { get; set; }
+            [DataMember(Name = "upload_url")]
+            public string upload_url { get; set; }
+            [DataMember(Name = "html_url")]
+            public string html_url { get; set; }
+            [DataMember(Name = "id")]
+            public int id { get; set; }
+            [DataMember(Name = "node_id")]
+            public string node_id { get; set; }
+            [DataMember(Name = "tag_name")]
+            public string tag_name { get; set; }
+            [DataMember(Name = "target_commitish")]
+            public string target_commitish { get; set; }
+            [DataMember(Name = "name")]
+            public string name { get; set; }
+            [DataMember(Name = "draft")]
+            public bool draft { get; set; }
 
-			public Int32 CustomTimeout
-			{
-				get
-				{
-					return m_intDefaultTimeout;
-				}
-				set
-				{
-					m_intDefaultTimeout = value;
-				}
-			}
+            [DataMember(Name = "author")]
+            public author_information author_info { get; set; }
+            
+            [DataMember(Name = "prerelease")]
+            public bool prerelease { get; set; }
+            [DataMember(Name = "created_at")]
+            public string created_at { get; set; }
+            [DataMember(Name = "published_at")]
+            public string published_at { get; set; }
+            
+            [DataMember(Name = "assets")]
+            public assets_information[] assets_info { get; set; }
+            
+            [DataMember(Name = "tarball_url")]
+            public string tarball_url { get; set; }
+            [DataMember(Name = "zipball_url")]
+            public string zipball_url { get; set; }
+            [DataMember(Name = "body")]
+            public string body { get; set; }
+            
+            public override string ToString()
+            {
+                StringBuilder sb = new StringBuilder();
+                sb.AppendLine(string.Format("[tag_name='{0}']", this.tag_name));
+                sb.AppendLine(string.Format("[name='{0}']", this.name));
 
-			public ExtendedWebClient() : this(30000) { }
+                int index = 0;
+                sb.AppendLine(string.Format("[assets count='{0}']", this.assets_info == null ? "0" : this.assets_info.Length.ToString()));
+                foreach (var k in this.assets_info)
+                {
+                    //k.name
+                    sb.AppendLine(string.Format("[asset index='{0}']",index));
+                    sb.AppendLine(string.Format("[name='{0}']",k.name));
+                    sb.AppendLine(string.Format("[name='{0}']",k.browser_download_url));
+                    index++;
+                }  
+                sb.AppendLine(string.Format("[tarball_url='{0}']", this.tarball_url));
+                sb.AppendLine(string.Format("[zipball_url='{0}']", this.zipball_url));
+                
+                
+                
+                return sb.ToString();
+            }
 
-			public ExtendedWebClient(int p_intTimeout)
-			{
-				this.m_intDefaultTimeout = p_intTimeout;
-				this.Headers["User-Agent"] = string.Format("Nexus Client v{0}", ProgrammeMetadata.VersionString);
-		                this.Headers["Accept"] = "text/html,application/json,application/xml,application/xhtml+xml";
-			}
+        }
+        [DataContract]
+        private class author_information
+        {
+            [DataMember(Name = "login")]
+            public string login { get; set; }
+            [DataMember(Name = "id")]
+            public int id { get; set; }
+            [DataMember(Name = "node_id")]
+            public string node_id { get; set; }
+            [DataMember(Name = "avatar_url")]
+            public string avatar_url { get; set; }
+            [DataMember(Name = "gravatar_id")]
+            public string gravatar_id { get; set; }
+            [DataMember(Name = "url")]
+            public string url { get; set; }
+            [DataMember(Name = "html_url")]
+            public string html_url { get; set; }
+            [DataMember(Name = "followers_url")]
+            public string followers_url { get; set; }
+            [DataMember(Name = "following_url")]
+            public string following_url { get; set; }
+            [DataMember(Name = "gists_url")]
+            public string gists_url { get; set; }
+            [DataMember(Name = "starred_url")]
+            public string starred_url { get; set; }
+            [DataMember(Name = "subscriptions_url")]
+            public string subscriptions_url { get; set; }
+            [DataMember(Name = "organizations_url")]
+            public string organizations_url { get; set; }
+            [DataMember(Name = "repos_url")]
+            public string repos_url { get; set; }
+            [DataMember(Name = "events_url")]
+            public string events_url { get; set; }
+            [DataMember(Name = "received_events_url")]
+            public string received_events_url { get; set; }
+            [DataMember(Name = "type")]
+            public string type { get; set; }
+            [DataMember(Name = "site_admin")]
+            public bool site_admin { get; set; }
+        }
+        [DataContract]
+        private class assets_information
+        {
+            [DataMember(Name = "url")]
+            public string url { get; set; }
+            [DataMember(Name = "id")]
+            public int id { get; set; }
+            [DataMember(Name = "node_id")]
+            public string node_id { get; set; }
+            [DataMember(Name = "name")]
+            public string name { get; set; }
+            [DataMember(Name = "label")]
+            public string label { get; set; }
+            
+            [DataMember(Name = "uploader")]
+            public author_information uploader_info { get; set; }
+            
+            [DataMember(Name = "content_type")]
+            public string content_type { get; set; }
+            [DataMember(Name = "state")]
+            public string state { get; set; }
+            [DataMember(Name = "download_count")]
+            public int download_count { get; set; }
+            [DataMember(Name = "created_at")]
+            public string created_at { get; set; }
+            [DataMember(Name = "published_at")]
+            public string published_at { get; set; }
+            [DataMember(Name = "browser_download_url")]
+            public string browser_download_url { get; set; }
+        }
+        #endregion
+        #region  GithubReleaseParser
+        private class GithubReleaseParser
+        {
+            public GithubReleaseParser()
+            {
+                this.LatestVersion = "";
+                this.LatestVersionUrl = "";             
+            }
 
-			protected override WebRequest GetWebRequest(Uri uri)
-			{
-				WebRequest w = base.GetWebRequest(uri);
-				w.Timeout = m_intDefaultTimeout;
-				return w;
-			}
-		}
+            public bool GetLatestVersion()
+            {
+                string data = "";
+                if (GetReleaseInformation(out data))
+                {
+                    if (!ParseReleaseInformation(data))
+                    {
+                        NexusClientLogger.Error.WriteLine("failed to parse github release information");
+                        return false;
+                    }
+                }
+                else
+                {
+                    NexusClientLogger.Error.WriteLine("failed to get github release information");
+                    return false;
+                }
+                return true;
+            }
 
-		protected const string m_strURI = "https://staticdelivery.nexusmods.com/NMM/releasenotes.html";
-		private bool m_booIsAutoCheck = false;
-		
-		#region Properties
+            private bool GetReleaseInformation(out string data)
+            {
+                data = "";
+                bool ret = false;
+                using (ExtendedWebClient wclNewVersion = new ExtendedWebClient(15000))
+                {
+                    try
+                    {
+                        data = wclNewVersion.DownloadString(NexusLinks.LatestGitHubVersion);
+                        ret = true;
+                    }
+                    catch (Exception e)
+                    {
+                        NexusClientLogger.Error.WriteLine("GithubReleaseParser::GetReleaseInformation:: error - {0}", e.Message);
+                        NexusClientLogger.Error.WriteLine(e.ToString());
+                        data = "";
+                        ret = false;
+                    }
+                }
 
-		/// <summary>
-		/// Gets the updater's name.
-		/// </summary>
-		/// <value>The updater's name.</value>
-		public override string Name
-		{
-			get
-			{
-				return String.Format("{0} Updater", EnvironmentInfo.Settings.ModManagerName);
-			}
-		}
+                return ret;
+            }
+            private bool ParseReleaseInformation(string data)
+            {
+                bool ret = false;
+                try
+                {
+                    List<GitHubReleaseJsonContract> ghrjc = JSONSerializer.Deserialize<List<GitHubReleaseJsonContract>>(data);
+                    if (ghrjc != null && ghrjc.Count > 0)
+                    {
+                        GitHubReleaseJsonContract latest = ghrjc[0];
+                        this.LatestVersion = latest.tag_name;
+                        this.LatestVersionUrl = latest.assets_info[0].browser_download_url;
+                    }
+                    ret = true;
+                }
+                catch (Exception e)
+                {
+                    NexusClientLogger.Error.WriteLine("GithubReleaseParser::GetReleaseInformation:: error - {0}", e.Message);
+                    NexusClientLogger.Error.WriteLine(e.ToString());
+                    data = "";
+                    ret = false;
+                }
 
-		private UpdateManager UpdateManager = null;
+                return ret;
+            }
 
-		#endregion
+            public string LatestVersion { get; private set; }
+            public string LatestVersionUrl { get; private set; }
+        }        
+#endregion
+        
+#region ExtendedWebClient
+        private class ExtendedWebClient : WebClient
+        {
+            private int m_intDefaultTimeout = 30000;
 
-		#region Constructors
+            public Int32 CustomTimeout
+            {
+                get
+                {
+                    return m_intDefaultTimeout;
+                }
+                set
+                {
+                    m_intDefaultTimeout = value;
+                }
+            }
 
-		/// <summary>
-		/// A simple constructor that initializes the object with the given values.
-		/// </summary>
-		/// <param name="p_eifEnvironmentInfo">The application's envrionment info.</param>
-		/// <param name="p_booIsAutoCheck">Whether the check is automatic or user requested.</param>
-		public ProgrammeUpdater(UpdateManager p_umUpdateManager, IEnvironmentInfo p_eifEnvironmentInfo, bool p_booIsAutoCheck)
-			: base(p_eifEnvironmentInfo)
-		{
-			m_booIsAutoCheck = p_booIsAutoCheck;
-			SetRequiresRestart(true);
-			UpdateManager = p_umUpdateManager;
-		}
+            public ExtendedWebClient() : this(30000) { }
 
-		#endregion
+            public ExtendedWebClient(int p_intTimeout)
+            {
+                this.m_intDefaultTimeout = p_intTimeout;
+                this.Headers["User-Agent"] = string.Format("Nexus Client v{0}", ProgrammeMetadata.VersionString);                
+                this.Headers["Accept"] = "application/json";
+                
+            }
 
-		/// <summary>
-		/// Performs the update.
-		/// </summary>
-		/// <returns><c>true</c> if the update completed successfully;
-		/// <c>false</c> otherwise.</returns>
-		public override bool Update()
-		{
-			Trace.TraceInformation("Checking for new client version...");
-			Trace.Indent();
-			SetProgressMaximum(2);
-			SetMessage(String.Format("Checking for new {0} version...", EnvironmentInfo.Settings.ModManagerName));
-			string strDownloadUri = String.Empty;
-			Version verNew = GetNewProgrammeVersion(out strDownloadUri);
-			SetProgress(1);
+            protected override WebRequest GetWebRequest(Uri uri)
+            {
+                WebRequest w = base.GetWebRequest(uri);
+                w.Timeout = m_intDefaultTimeout;
+                return w;
+            }
+        }
+#endregion
 
-			if (CancelRequested)
-			{
-				Trace.Unindent();
-				return CancelUpdate();
-			}
+        protected const string m_strURI = "https://staticdelivery.nexusmods.com/NMM/releasenotes.html";
+        private bool m_booIsAutoCheck = false;
+        
+#region Properties
 
-			if (verNew == new Version("69.69.69.69"))
-			{
-				SetMessage("Could not get version information from the update server.");
-				return false;
-			}
+        /// <summary>
+        /// Gets the updater's name.
+        /// </summary>
+        /// <value>The updater's name.</value>
+        public override string Name
+        {
+            get
+            {
+                return String.Format("{0} Updater", EnvironmentInfo.Settings.ModManagerName);
+            }
+        }
 
-			StringBuilder stbPromptMessage = new StringBuilder();
-			DialogResult drResult = DialogResult.No;
+        private UpdateManager UpdateManager = null;
 
-			string strReleaseNotes = String.Empty;
+#endregion
 
-			if ((verNew > new Version(ProgrammeMetadata.VersionString)) && !String.IsNullOrEmpty(strDownloadUri))
-			{
-				string strCheckDownloadedInstaller = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Temp", Path.GetFileName(strDownloadUri));
-				
-				stbPromptMessage.AppendFormat("A new version of {0} is available ({1}).{2}Would you like to download and install it?", EnvironmentInfo.Settings.ModManagerName, verNew, Environment.NewLine).AppendLine();
-				stbPromptMessage.AppendLine();
-				stbPromptMessage.AppendLine();
-				stbPromptMessage.AppendLine("Below you can find the change log for the new release:");
+#region Constructors
 
-				try
-				{
-					HttpWebRequest request = (HttpWebRequest)WebRequest.Create(m_strURI);
-					HttpWebResponse response = (HttpWebResponse)request.GetResponse();
+        /// <summary>
+        /// A simple constructor that initializes the object with the given values.
+        /// </summary>
+        /// <param name="p_eifEnvironmentInfo">The application's envrionment info.</param>
+        /// <param name="p_booIsAutoCheck">Whether the check is automatic or user requested.</param>
+        public ProgrammeUpdater(UpdateManager p_umUpdateManager, IEnvironmentInfo p_eifEnvironmentInfo, bool p_booIsAutoCheck)
+            : base(p_eifEnvironmentInfo)
+        {
+            m_booIsAutoCheck = p_booIsAutoCheck;
+            SetRequiresRestart(true);
+            UpdateManager = p_umUpdateManager;
+        }
 
-					if (response.StatusCode == HttpStatusCode.OK)
-					{
-						Stream receiveStream = response.GetResponseStream();
-						StreamReader readStream = null;
+#endregion
 
-						if (response.CharacterSet == null)
-						{
-							readStream = new StreamReader(receiveStream);
-						}
-						else
-						{
-							readStream = new StreamReader(receiveStream, Encoding.GetEncoding(response.CharacterSet));
-						}
+        /// <summary>
+        /// Performs the update.
+        /// </summary>
+        /// <returns><c>true</c> if the update completed successfully;
+        /// <c>false</c> otherwise.</returns>
+        public override bool Update()
+        {
+            Trace.TraceInformation("Checking for new client version...");
+            Trace.Indent();
+            SetProgressMaximum(2);
+            SetMessage(String.Format("Checking for new {0} version...", EnvironmentInfo.Settings.ModManagerName));
+            string strDownloadUri = String.Empty;
+            Version verNew = GetNewProgrammeVersion(out strDownloadUri);
+            SetProgress(1);
 
-						strReleaseNotes = readStream.ReadToEnd();
+            if (CancelRequested)
+            {
+                Trace.Unindent();
+                return CancelUpdate();
+            }
 
-						response.Close();
-						readStream.Close();
-					}
+            if (verNew == new Version("69.69.69.69"))
+            {
+                SetMessage("Could not get version information from the update server.");
+                return false;
+            }
 
-				}
-				catch
-				{
-					strReleaseNotes = "Unable to retrieve the Release Notes.";
-				}
+            StringBuilder stbPromptMessage = new StringBuilder();
+            DialogResult drResult = DialogResult.No;
 
-				try
-				{
-					//the extended message box contains an activex control wich must be run in an STA thread,
-					// we can't control what thread this gets called on, so create one if we need to
-					ThreadStart actShowMessage = () => drResult = ExtendedMessageBox.Show(null, stbPromptMessage.ToString(), "New version available", strReleaseNotes, 700, 450, ExtendedMessageBoxButtons.Backup, MessageBoxIcon.Question);
-					ApartmentState astState = ApartmentState.Unknown;
-					Thread.CurrentThread.TrySetApartmentState(astState);
-					if (astState == ApartmentState.STA)
-						actShowMessage();
-					else
-					{
-						Thread thdMessage = new Thread(actShowMessage);
-						thdMessage.SetApartmentState(ApartmentState.STA);
-						thdMessage.Start();
-						thdMessage.Join();
-					}
+            string strReleaseNotes = String.Empty;
 
-				}
-				catch
-				{
-				}
+            if ((verNew > new Version(ProgrammeMetadata.VersionString)) && !String.IsNullOrEmpty(strDownloadUri))
+            {
+                string strCheckDownloadedInstaller = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Temp", Path.GetFileName(strDownloadUri));
+                
+                stbPromptMessage.AppendFormat("A new version of {0} is available ({1}).{2}Would you like to download and install it?", EnvironmentInfo.Settings.ModManagerName, verNew, Environment.NewLine).AppendLine();
+                stbPromptMessage.AppendLine();
+                stbPromptMessage.AppendLine();
+                stbPromptMessage.AppendLine("Below you can find the change log for the new release:");
 
-				if (drResult == DialogResult.Cancel)
-				{
-					Trace.Unindent();
-					return CancelUpdate();
-				}
+                try
+                {
+                    HttpWebRequest request = (HttpWebRequest)WebRequest.Create(m_strURI);
+                    HttpWebResponse response = (HttpWebResponse)request.GetResponse();
 
-				if (drResult == DialogResult.Yes)
-				{
-					UpdateManager.CreateBackup();
-				}
+                    if (response.StatusCode == HttpStatusCode.OK)
+                    {
+                        Stream receiveStream = response.GetResponseStream();
+                        StreamReader readStream = null;
 
-				if (File.Exists(strCheckDownloadedInstaller))
-				{
-					SetMessage("Launching installer...");
-					ProcessStartInfo psiInfo = new ProcessStartInfo(strCheckDownloadedInstaller);
-					Process.Start(psiInfo);
-					Trace.Unindent();
-					return true;
-				}
+                        if (response.CharacterSet == null)
+                        {
+                            readStream = new StreamReader(receiveStream);
+                        }
+                        else
+                        {
+                            readStream = new StreamReader(receiveStream, Encoding.GetEncoding(response.CharacterSet));
+                        }
 
-				SetMessage(String.Format("Downloading new {0} version...", EnvironmentInfo.Settings.ModManagerName));
+                        strReleaseNotes = readStream.ReadToEnd();
 
-				string strNewInstaller = string.Empty;
-				try
-				{
-					strNewInstaller = DownloadFile(new Uri(String.Format(strDownloadUri)));
-				}
-				catch (FileNotFoundException)
-				{
-					StringBuilder stbAVMessage = new StringBuilder();
-					stbAVMessage.AppendLine("Unable to find the installer to download:");
-					stbAVMessage.AppendLine("this could be caused by a network issue or by your Firewall.");
-					stbAVMessage.AppendLine("As a result you won't be able to automatically update the program.");
-					stbAVMessage.AppendLine();
-					stbAVMessage.AppendFormat("You can download the update manually from:");
-					stbAVMessage.AppendLine(NexusLinks.Releases);
-					try
-					{
-						//the extended message box contains an activex control wich must be run in an STA thread,
-						// we can't control what thread this gets called on, so create one if we need to
-						ThreadStart actShowMessage = () => drResult = ExtendedMessageBox.Show(null, stbAVMessage.ToString(), "Unable to update", MessageBoxButtons.OK, MessageBoxIcon.Information);
-						ApartmentState astState = ApartmentState.Unknown;
-						Thread.CurrentThread.TrySetApartmentState(astState);
-						if (astState == ApartmentState.STA)
-							actShowMessage();
-						else
-						{
-							Thread thdMessage = new Thread(actShowMessage);
-							thdMessage.SetApartmentState(ApartmentState.STA);
-							thdMessage.Start();
-							thdMessage.Join();
-						}
+                        response.Close();
+                        readStream.Close();
+                    }
 
-					}
-					catch
-					{
-					}
+                }
+                catch
+                {
+                    strReleaseNotes = "Unable to retrieve the Release Notes.";
+                }
 
-					Trace.Unindent();
-					return CancelUpdate();
-				}
+                try
+                {
+                    //the extended message box contains an activex control wich must be run in an STA thread,
+                    // we can't control what thread this gets called on, so create one if we need to
+                    ThreadStart actShowMessage = () => drResult = ExtendedMessageBox.Show(null, stbPromptMessage.ToString(), "New version available", strReleaseNotes, 700, 450, ExtendedMessageBoxButtons.Backup, MessageBoxIcon.Question);
+                    ApartmentState astState = ApartmentState.Unknown;
+                    Thread.CurrentThread.TrySetApartmentState(astState);
+                    if (astState == ApartmentState.STA)
+                        actShowMessage();
+                    else
+                    {
+                        Thread thdMessage = new Thread(actShowMessage);
+                        thdMessage.SetApartmentState(ApartmentState.STA);
+                        thdMessage.Start();
+                        thdMessage.Join();
+                    }
 
-				SetProgress(2);
+                }
+                catch
+                {
+                }
 
-				if (CancelRequested)
-				{
-					Trace.Unindent();
-					return CancelUpdate();
-				}
+                if (drResult == DialogResult.Cancel)
+                {
+                    Trace.Unindent();
+                    return CancelUpdate();
+                }
 
-				if (!String.IsNullOrEmpty(strNewInstaller))
-				{
-					string strOldPath = strNewInstaller;
-					strNewInstaller = Path.Combine(Path.GetTempPath(), Path.GetFileName(strNewInstaller));
-					FileUtil.ForceDelete(strNewInstaller);
+                if (drResult == DialogResult.Yes)
+                {
+                    UpdateManager.CreateBackup();
+                }
 
-					try
-					{
-						File.Move(strOldPath, strNewInstaller);
-					}
-					catch (FileNotFoundException)
-					{
-						StringBuilder stbAVMessage = new StringBuilder();
-						stbAVMessage.AppendLine("Unable to find the downloaded update:");
-						stbAVMessage.AppendLine("this could be caused by a network issue or by your anti-virus software deleting it falsely flagging the installer as a virus.");
-						stbAVMessage.AppendLine("As a result you won't be able to automatically update the program.");
-						stbAVMessage.AppendLine();
-						stbAVMessage.AppendFormat("To fix this issue you need to add {0}'s executable and all its folders to your", EnvironmentInfo.Settings.ModManagerName).AppendLine();
-						stbAVMessage.AppendLine("anti-virus exception list. You can also download the update manually from:");
-						stbAVMessage.AppendLine(NexusLinks.Releases);
+                if (File.Exists(strCheckDownloadedInstaller))
+                {
+                    SetMessage("Launching installer...");
+                    ProcessStartInfo psiInfo = new ProcessStartInfo(strCheckDownloadedInstaller);
+                    Process.Start(psiInfo);
+                    Trace.Unindent();
+                    return true;
+                }
 
-						try
-						{
-							//the extended message box contains an activex control wich must be run in an STA thread,
-							// we can't control what thread this gets called on, so create one if we need to
-							ThreadStart actShowMessage = () => drResult = ExtendedMessageBox.Show(null, stbAVMessage.ToString(), "Unable to update", MessageBoxButtons.OK, MessageBoxIcon.Information);
-							ApartmentState astState = ApartmentState.Unknown;
-							Thread.CurrentThread.TrySetApartmentState(astState);
-							if (astState == ApartmentState.STA)
-								actShowMessage();
-							else
-							{
-								Thread thdMessage = new Thread(actShowMessage);
-								thdMessage.SetApartmentState(ApartmentState.STA);
-								thdMessage.Start();
-								thdMessage.Join();
-							}
+                SetMessage(String.Format("Downloading new {0} version...", EnvironmentInfo.Settings.ModManagerName));
 
-						}
-						catch
-						{
-						}
+                string strNewInstaller = string.Empty;
+                try
+                {
+                    strNewInstaller = DownloadFile(new Uri(String.Format(strDownloadUri)));
+                }
+                catch (FileNotFoundException)
+                {
+                    StringBuilder stbAVMessage = new StringBuilder();
+                    stbAVMessage.AppendLine("Unable to find the installer to download:");
+                    stbAVMessage.AppendLine("this could be caused by a network issue or by your Firewall.");
+                    stbAVMessage.AppendLine("As a result you won't be able to automatically update the program.");
+                    stbAVMessage.AppendLine();
+                    stbAVMessage.AppendFormat("You can download the update manually from:");
+                    stbAVMessage.AppendLine(NexusLinks.GithubReleases);
+                    try
+                    {
+                        //the extended message box contains an activex control wich must be run in an STA thread,
+                        // we can't control what thread this gets called on, so create one if we need to
+                        ThreadStart actShowMessage = () => drResult = ExtendedMessageBox.Show(null, stbAVMessage.ToString(), "Unable to update", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                        ApartmentState astState = ApartmentState.Unknown;
+                        Thread.CurrentThread.TrySetApartmentState(astState);
+                        if (astState == ApartmentState.STA)
+                            actShowMessage();
+                        else
+                        {
+                            Thread thdMessage = new Thread(actShowMessage);
+                            thdMessage.SetApartmentState(ApartmentState.STA);
+                            thdMessage.Start();
+                            thdMessage.Join();
+                        }
 
-						Trace.Unindent();
-						return CancelUpdate();
-					}
+                    }
+                    catch
+                    {
+                    }
 
-					SetMessage("Launching installer...");
-					ProcessStartInfo psiInfo = new ProcessStartInfo(strNewInstaller);
-					Process.Start(psiInfo);
-					Trace.Unindent();
-					return true;
-				}
-			}
-			else if (!m_booIsAutoCheck)
-			{
-				stbPromptMessage.AppendFormat("{0} is already up to date.", EnvironmentInfo.Settings.ModManagerName).AppendLine();
-				stbPromptMessage.AppendLine();
-				stbPromptMessage.AppendLine();
-				stbPromptMessage.AppendLine("NOTE: You can find the release notes and past versions here:");
-				stbPromptMessage.AppendLine(NexusLinks.Releases);
+                    Trace.Unindent();
+                    return CancelUpdate();
+                }
 
-				try
-				{
-					//the extended message box contains an activex control wich must be run in an STA thread,
-					// we can't control what thread this gets called on, so create one if we need to
-					ThreadStart actShowMessage = () => drResult = ExtendedMessageBox.Show(null, stbPromptMessage.ToString(), "Up to date", MessageBoxButtons.OK, MessageBoxIcon.Information);
-					ApartmentState astState = ApartmentState.Unknown;
-					Thread.CurrentThread.TrySetApartmentState(astState);
-					if (astState == ApartmentState.STA)
-						actShowMessage();
-					else
-					{
-						Thread thdMessage = new Thread(actShowMessage);
-						thdMessage.SetApartmentState(ApartmentState.STA);
-						thdMessage.Start();
-						thdMessage.Join();
-					}
+                SetProgress(2);
 
-				}
-				catch
-				{
-				}
-			}
+                if (CancelRequested)
+                {
+                    Trace.Unindent();
+                    return CancelUpdate();
+                }
 
-			SetMessage(String.Format("{0} is already up to date.", EnvironmentInfo.Settings.ModManagerName));
-			SetProgress(2);
-			Trace.Unindent();
-			return true;
-		}
+                if (!String.IsNullOrEmpty(strNewInstaller))
+                {
+                    string strOldPath = strNewInstaller;
+                    strNewInstaller = Path.Combine(Path.GetTempPath(), Path.GetFileName(strNewInstaller));
+                    FileUtil.ForceDelete(strNewInstaller);
 
-		/// <summary>
-		/// Cancels the update.
-		/// </summary>
-		/// <remarks>
-		/// This is a convience method that allows the setting of the message and
-		/// the determination of the return value in one call.
-		/// </remarks>
-		/// <returns>Always <c>true</c>.</returns>
-		private bool CancelUpdate()
-		{
-			SetMessage(String.Format("Cancelled {0} update.", EnvironmentInfo.Settings.ModManagerName));
-			SetProgress(2);
-			return true;
-		}
+                    try
+                    {
+                        File.Move(strOldPath, strNewInstaller);
+                    }
+                    catch (FileNotFoundException)
+                    {
+                        StringBuilder stbAVMessage = new StringBuilder();
+                        stbAVMessage.AppendLine("Unable to find the downloaded update:");
+                        stbAVMessage.AppendLine("this could be caused by a network issue or by your anti-virus software deleting it falsely flagging the installer as a virus.");
+                        stbAVMessage.AppendLine("As a result you won't be able to automatically update the program.");
+                        stbAVMessage.AppendLine();
+                        stbAVMessage.AppendFormat("To fix this issue you need to add {0}'s executable and all its folders to your", EnvironmentInfo.Settings.ModManagerName).AppendLine();
+                        stbAVMessage.AppendLine("anti-virus exception list. You can also download the update manually from:");
+                        stbAVMessage.AppendLine(NexusLinks.GithubReleases);
 
-		/// <summary>
-		/// Gets the newest available programme version.
-		/// </summary>
-		/// <returns>The newest available programme version,
-		/// or 69.69.69.69 if now information could be retrieved.</returns>
-		private Version GetNewProgrammeVersion(out string p_strDownloadUri)
-		{
-			ExtendedWebClient wclNewVersion = new ExtendedWebClient(15000);
-			Version verNew = new Version("69.69.69.69");
-			p_strDownloadUri = String.Empty;
+                        try
+                        {
+                            //the extended message box contains an activex control wich must be run in an STA thread,
+                            // we can't control what thread this gets called on, so create one if we need to
+                            ThreadStart actShowMessage = () => drResult = ExtendedMessageBox.Show(null, stbAVMessage.ToString(), "Unable to update", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                            ApartmentState astState = ApartmentState.Unknown;
+                            Thread.CurrentThread.TrySetApartmentState(astState);
+                            if (astState == ApartmentState.STA)
+                                actShowMessage();
+                            else
+                            {
+                                Thread thdMessage = new Thread(actShowMessage);
+                                thdMessage.SetApartmentState(ApartmentState.STA);
+                                thdMessage.Start();
+                                thdMessage.Join();
+                            }
 
-			try
-			{
-				string strNewVersion = wclNewVersion.DownloadString(NexusLinks.LatestVersion);
-				strNewVersion = strNewVersion.TrimStart(new char[] { '\"' });
-				strNewVersion = strNewVersion.TrimEnd(new char[] { '\"' });
-				if (!String.IsNullOrEmpty(strNewVersion))
-				{
-					verNew = new Version(strNewVersion.Split('|')[0]);
-					p_strDownloadUri = strNewVersion.Split('|')[1];
-					p_strDownloadUri = p_strDownloadUri.Replace(@"\/", @"/");
-				}
-			}
-			catch (WebException)
-			{
-				try
-				{
-					string strNewVersion = wclNewVersion.DownloadString(NexusLinks.LatestVersion4dot5);
-					strNewVersion = strNewVersion.TrimStart(new char[] { '\"' });
-			                strNewVersion = strNewVersion.TrimEnd(new char[] { '\"' });
-					if (!String.IsNullOrEmpty(strNewVersion))
-					{
-						verNew = new Version(strNewVersion.Split('|')[0]);
-						p_strDownloadUri = strNewVersion.Split('|')[1];
-						p_strDownloadUri = p_strDownloadUri.Replace(@"\/", @"/");
-					}
-				}
-				catch (WebException e)
-				{
-					Trace.TraceError(String.Format("Could not connect to update server: {0}", e.Message));
-				}
-				catch (ArgumentException e)
-				{
-					Trace.TraceError(String.Format("Unexpected response from the server: {0}", e.Message));
-				}
-			}
-			catch (ArgumentException e)
-			{
-				Trace.TraceError(String.Format("Unexpected response from the server: {0}", e.Message));
-			}
+                        }
+                        catch
+                        {
+                        }
 
-			return verNew;
-		}
-	}
+                        Trace.Unindent();
+                        return CancelUpdate();
+                    }
+
+                    SetMessage("Launching installer...");
+                    ProcessStartInfo psiInfo = new ProcessStartInfo(strNewInstaller);
+                    Process.Start(psiInfo);
+                    Trace.Unindent();
+                    return true;
+                }
+            }
+            else if (!m_booIsAutoCheck)
+            {
+                stbPromptMessage.AppendFormat("{0} is already up to date.", EnvironmentInfo.Settings.ModManagerName).AppendLine();
+                stbPromptMessage.AppendLine();
+                stbPromptMessage.AppendLine();
+                stbPromptMessage.AppendLine("NOTE: You can find the release notes and past versions here:");
+                stbPromptMessage.AppendLine(NexusLinks.GithubReleases);
+
+                try
+                {
+                    //the extended message box contains an activex control wich must be run in an STA thread,
+                    // we can't control what thread this gets called on, so create one if we need to
+                    ThreadStart actShowMessage = () => drResult = ExtendedMessageBox.Show(null, stbPromptMessage.ToString(), "Up to date", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    ApartmentState astState = ApartmentState.Unknown;
+                    Thread.CurrentThread.TrySetApartmentState(astState);
+                    if (astState == ApartmentState.STA)
+                        actShowMessage();
+                    else
+                    {
+                        Thread thdMessage = new Thread(actShowMessage);
+                        thdMessage.SetApartmentState(ApartmentState.STA);
+                        thdMessage.Start();
+                        thdMessage.Join();
+                    }
+
+                }
+                catch
+                {
+                }
+            }
+
+            SetMessage(String.Format("{0} is already up to date.", EnvironmentInfo.Settings.ModManagerName));
+            SetProgress(2);
+            Trace.Unindent();
+            return true;
+        }
+
+        /// <summary>
+        /// Cancels the update.
+        /// </summary>
+        /// <remarks>
+        /// This is a convience method that allows the setting of the message and
+        /// the determination of the return value in one call.
+        /// </remarks>
+        /// <returns>Always <c>true</c>.</returns>
+        private bool CancelUpdate()
+        {
+            SetMessage(String.Format("Cancelled {0} update.", EnvironmentInfo.Settings.ModManagerName));
+            SetProgress(2);
+            return true;
+        }
+
+        /// <summary>
+        /// Gets the newest available programme version.
+        /// </summary>
+        /// <returns>The newest available programme version,
+        /// or 69.69.69.69 if now information could be retrieved.</returns>
+        private Version GetNewProgrammeVersion(out string p_strDownloadUri)
+        {
+            ExtendedWebClient wclNewVersion = new ExtendedWebClient(15000);
+            Version verNew = new Version("69.69.69.69");
+            p_strDownloadUri = String.Empty;
+            try
+            {
+                GithubReleaseParser release = new GithubReleaseParser();
+
+                if (release.GetLatestVersion())
+                {
+                    verNew = new Version(release.LatestVersion);
+                    p_strDownloadUri = release.LatestVersionUrl;
+                    NexusClientLogger.Debug.WriteLine("latest version = {0}", verNew.ToString());
+                    NexusClientLogger.Debug.WriteLine("latest version url = {0}", p_strDownloadUri);
+                }
+            }
+            catch (Exception e)
+            {
+
+                NexusClientLogger.Error.WriteLine("ProgrammeUpdater::GetNewProgrammeVersion:: error - {0}", e.Message);
+                NexusClientLogger.Error.WriteLine(e.ToString());
+                
+            }
+
+            return verNew;
+        }
+    }
 }

--- a/NexusClient/Updating/ProgrammeUpdater.cs
+++ b/NexusClient/Updating/ProgrammeUpdater.cs
@@ -225,8 +225,8 @@ namespace Nexus.Client.Updating
                         GitHubReleaseJsonContract latest = ghrjc[0];
                         this.LatestVersion = latest.tag_name;
                         this.LatestVersionUrl = latest.assets_info[0].browser_download_url;
+                        ret = true;
                     }
-                    ret = true;
                 }
                 catch (Exception e)
                 {

--- a/NexusClient/Updating/ProgrammeUpdater.cs
+++ b/NexusClient/Updating/ProgrammeUpdater.cs
@@ -180,13 +180,13 @@ namespace Nexus.Client.Updating
                 {
                     if (!ParseReleaseInformation(data))
                     {
-                        NexusClientLogger.Error.WriteLine("failed to parse github release information");
+                        Console.Error.WriteLine("failed to parse github release information");
                         return false;
                     }
                 }
                 else
                 {
-                    NexusClientLogger.Error.WriteLine("failed to get github release information");
+                    Console.Error.WriteLine("failed to get github release information");
                     return false;
                 }
                 return true;
@@ -200,13 +200,13 @@ namespace Nexus.Client.Updating
                 {
                     try
                     {
-                        data = wclNewVersion.DownloadString(NexusLinks.LatestGitHubVersion);
+                        data = wclNewVersion.DownloadString(NexusLinks.LatestVersion);
                         ret = true;
                     }
                     catch (Exception e)
                     {
-                        NexusClientLogger.Error.WriteLine("GithubReleaseParser::GetReleaseInformation:: error - {0}", e.Message);
-                        NexusClientLogger.Error.WriteLine(e.ToString());
+                        Console.Error.WriteLine("GithubReleaseParser::GetReleaseInformation:: error - {0}", e.Message);
+                        Console.Error.WriteLine(e.ToString());
                         data = "";
                         ret = false;
                     }
@@ -230,8 +230,8 @@ namespace Nexus.Client.Updating
                 }
                 catch (Exception e)
                 {
-                    NexusClientLogger.Error.WriteLine("GithubReleaseParser::GetReleaseInformation:: error - {0}", e.Message);
-                    NexusClientLogger.Error.WriteLine(e.ToString());
+                    Console.Error.WriteLine("GithubReleaseParser::GetReleaseInformation:: error - {0}", e.Message);
+                    Console.Error.WriteLine(e.ToString());
                     data = "";
                     ret = false;
                 }
@@ -606,15 +606,15 @@ namespace Nexus.Client.Updating
                 {
                     verNew = new Version(release.LatestVersion);
                     p_strDownloadUri = release.LatestVersionUrl;
-                    NexusClientLogger.Debug.WriteLine("latest version = {0}", verNew.ToString());
-                    NexusClientLogger.Debug.WriteLine("latest version url = {0}", p_strDownloadUri);
+                    Console.Error.WriteLine("latest version = {0}", verNew.ToString());
+                    Console.Error.WriteLine("latest version url = {0}", p_strDownloadUri);
                 }
             }
             catch (Exception e)
             {
 
-                NexusClientLogger.Error.WriteLine("ProgrammeUpdater::GetNewProgrammeVersion:: error - {0}", e.Message);
-                NexusClientLogger.Error.WriteLine(e.ToString());
+                Console.Error.WriteLine("ProgrammeUpdater::GetNewProgrammeVersion:: error - {0}", e.Message);
+                Console.Error.WriteLine(e.ToString());
                 
             }
 

--- a/NexusClient/Updating/ProgrammeUpdater.cs
+++ b/NexusClient/Updating/ProgrammeUpdater.cs
@@ -235,7 +235,7 @@ namespace Nexus.Client.Updating
 								{
 									if (!string.IsNullOrEmpty(latest.assets_info[0].browser_download_url))
 									{
-                                        this.LatestVersionUrl = latest.assets_info[0].browser_download_url);
+                                        this.LatestVersionUrl = latest.assets_info[0].browser_download_url;
 									}
 								}
 							}

--- a/Util/JSONSerializer.cs
+++ b/Util/JSONSerializer.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Json;
+using System.Text;
+using System.ComponentModel;
+
+namespace Nexus.Client.Util
+{
+    public static class JSONSerializer
+    {
+        public static string Serialize<T>(T aObject) where T : new()
+        {
+            T serializedObj = new T();
+            MemoryStream ms = new MemoryStream();
+            DataContractJsonSerializer ser = new DataContractJsonSerializer(typeof(T));
+            ser.WriteObject(ms, serializedObj);
+            byte[] json = ms.ToArray();
+            ms.Close();
+            return Encoding.UTF8.GetString(json, 0, json.Length);
+        }
+
+        public static T Deserialize<T>(string aJSON) where T : new()
+        {
+            T deserializedObj = default(T);
+            MemoryStream ms = new MemoryStream(Encoding.UTF8.GetBytes(aJSON));
+            DataContractJsonSerializer ser = new DataContractJsonSerializer(typeof(T));
+            deserializedObj = (T)ser.ReadObject(ms);
+            ms.Close();
+            return deserializedObj;
+        }
+    }
+}

--- a/Util/Util.csproj
+++ b/Util/Util.csproj
@@ -45,14 +45,15 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase">
-      <RequiredTargetFramework>3.0</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Runtime.Serialization">
+      <HintPath>..\..\..\..\..\usr\lib\mono\4.6-api\System.Runtime.Serialization.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -81,6 +82,7 @@
     <Compile Include="RegistryUtil.cs" />
     <Compile Include="TextUtil.cs" />
     <Compile Include="ThreadSafeSevenZipExtractor.cs" />
+    <Compile Include="JSONSerializer.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ChinhDo.Transactions.FileManager\ChinhDo.Transactions.FileManager.csproj">


### PR DESCRIPTION
I just pushed a commit to grab the releases from github rather than nexusmods
and it should fix issue: #346

It seems that legacy-api urls require a user-agent of : "Nexus Client v0.65.5" (or later).
This works for any legacy-api that does not require a login.

However, to use an ordinary webclient (with proper user-agent) you must pass the login authentication token as a cookie; although it would better to use the repository api with channel/proxy factory.

But, releases are now obtained from github using their release api:
https://api.github.com/repos/Nexus-Mods/Nexus-Mod-Manager/releases

