### PR TITLE
Removing LOOT launch parameter "Skyrim" for Skyrim SE.

### DIFF
--- a/SkyrimSE/SkyrimSESupportedTools.cs
+++ b/SkyrimSE/SkyrimSESupportedTools.cs
@@ -162,7 +162,7 @@ namespace Nexus.Client.Games.SkyrimSE
 			Trace.Indent();
 			string strCommand = GetLOOTLaunchCommand();
 			Trace.TraceInformation("Command: " + strCommand);
-            Launch(strCommand, "--game=Skyrim");
+            Launch(strCommand, null);
         }
 
 		private void LaunchWryeBash()


### PR DESCRIPTION
As reported in #373 I made some bad assumptions for Skyrim/SkyrimSE and LOOT - it's now reverted so only Skyrim will have the launch parameter `--game=Skyrim`, SkyrimSE has launch parameter `null` again.

Should resolve #373.