### PR TITLE
Handle missing Fallout 4 executable

### DIFF
--- a/GamebryoBase/GamebryoGameModeFactory.cs
+++ b/GamebryoBase/GamebryoGameModeFactory.cs
@@ -131,6 +131,11 @@ namespace Nexus.Client.Games.Gamebryo
 				gmdGameMode = null;
 				p_imsWarning = new ViewMessage(String.Format(e.Message), null, "SorterException", MessageBoxIcon.Error);
 			}
+            catch (FileNotFoundException e)
+            {
+                gmdGameMode = null;
+                p_imsWarning = new ViewMessage(string.Format(e.Message), null, "FileNotFoundException", MessageBoxIcon.Error);
+            }
 
 			return gmdGameMode;
 		}

--- a/GamebryoBase/PluginManagement/LoadOrderManager/PluginOrderManager.cs
+++ b/GamebryoBase/PluginManagement/LoadOrderManager/PluginOrderManager.cs
@@ -317,10 +317,11 @@ namespace Nexus.Client.Games.Gamebryo.PluginManagement.LoadOrder
 						}
 						IgnoreOfficialPlugins = true;
                     }
-                    catch (ArgumentNullException)
+                    catch (ArgumentNullException e)
                     {
-                        // No idea what to do with this, guess we'll rethrow it for now.
-                        throw;
+                        var ex = new FileNotFoundException("Could not initialize Fallout4 Game Mode: Could not find the Fallout 4 executable.", Path.Combine(GameMode.ExecutablePath, "Fallout4.exe"), e);
+                        TraceUtil.TraceException(ex);
+                        throw ex;
                     }
 					break;
 				case "SkyrimSE":


### PR DESCRIPTION
Since it seems to be a very common thing that Fallout4.exe goes missing, this fix will return the user to game mode selection if this happens.

Will solve #300 , or come as close as possible to do so. Nothing we can do about users moving files around on their own.