### PR TITLE
Auto creating missing folders, because you are going to need them no …

### DIFF
--- a/NexusClient/ApplicationInitializer.cs
+++ b/NexusClient/ApplicationInitializer.cs
@@ -768,30 +768,47 @@ namespace Nexus.Client
 
 			Trace.TraceInformation("Registering supported Script Types...");
 			Trace.Indent();
-			IScriptTypeRegistry stgScriptTypeRegistry = ScriptTypeRegistry.DiscoverScriptTypes(Path.Combine(Path.GetDirectoryName(Application.ExecutablePath), "ScriptTypes"), p_gmdGameMode, DeletedDLL);
-			if (stgScriptTypeRegistry.Types.Count == 0)
-			{
-				p_vwmErrorMessage = new ViewMessage("No script types were found.", null, "No Script Types", MessageBoxIcon.Error);
-				return null;
+
+		    var path = Path.Combine(Path.GetDirectoryName(Application.ExecutablePath), "ScriptTypes");
+
+		    if (!Directory.Exists(path))
+		        Directory.CreateDirectory(path);
+
+            IScriptTypeRegistry stgScriptTypeRegistry = ScriptTypeRegistry.DiscoverScriptTypes(path, p_gmdGameMode, DeletedDLL);
+
+		    if (stgScriptTypeRegistry.Types.Count == 0)
+		    {
+		        string strDebugInfo = null;
+#if DEBUG
+		        strDebugInfo = $"\nZero script types found (dlls) in \"{path}\". Make sure to compile CSharpScript, ModScript & XmlScript to fix the problem.";
+#endif
+
+                p_vwmErrorMessage = new ViewMessage("No script types were found." + strDebugInfo, null, "No Script Types", MessageBoxIcon.Error);
+
+		        return null;
 			}
 			Trace.TraceInformation("Found {0} script types.", stgScriptTypeRegistry.Types.Count);
 			Trace.Unindent();
 
 			Trace.TraceInformation("Registering supported mod formats...");
 			Trace.Indent();
-			IModFormatRegistry mfrModFormatRegistry = ModFormatRegistry.DiscoverFormats(mcmModCacheManager, p_gmdGameMode.SupportedFormats, stgScriptTypeRegistry, Path.Combine(Path.GetDirectoryName(Application.ExecutablePath), "ModFormats"));
-			if (mfrModFormatRegistry.Formats.Count == 0)
+
+		    IModFormatRegistry mfrModFormatRegistry = ModFormatRegistry.DiscoverFormats(mcmModCacheManager, p_gmdGameMode.SupportedFormats, stgScriptTypeRegistry, Path.Combine(Path.GetDirectoryName(Application.ExecutablePath), "ModFormats"));
+
+		    if (mfrModFormatRegistry.Formats.Count == 0)
 			{
 				p_vwmErrorMessage = new ViewMessage("No mod formats were found.", null, "No Mod Formats", MessageBoxIcon.Error);
 				return null;
 			}
-			Trace.TraceInformation("Found {0} formats.", mfrModFormatRegistry.Formats.Count);
+
+		    Trace.TraceInformation("Found {0} formats.", mfrModFormatRegistry.Formats.Count);
 			Trace.Unindent();
 
 			Trace.TraceInformation("Finding managed mods...");
 			Trace.Indent();
 			ModRegistry mrgModRegistry = null;
-			try
+
+		    try
 			{
 				mrgModRegistry = ModRegistry.DiscoverManagedMods(mfrModFormatRegistry, mcmModCacheManager, p_gmdGameMode.GameModeEnvironmentInfo.ModDirectory, EnvironmentInfo.Settings.ScanSubfoldersForMods, EnvironmentInfo, p_gmdGameMode, p_gmdGameMode.GameModeEnvironmentInfo.ModCacheDirectory, p_gmdGameMode.GameModeEnvironmentInfo.ModDownloadCacheDirectory, p_gmdGameMode.GameModeEnvironmentInfo.ModReadMeDirectory, p_gmdGameMode.GameModeEnvironmentInfo.CategoryDirectory, Path.Combine(p_gmdGameMode.GameModeEnvironmentInfo.ModDirectory, VirtualModActivator.ACTIVATOR_FOLDER), Path.Combine(p_gmdGameMode.GameModeEnvironmentInfo.ModDirectory, VirtualModActivator.ACTIVATOR_LINK_FOLDER), Path.Combine(p_gmdGameMode.GameModeEnvironmentInfo.ModDirectory, ProfileManager.PROFILE_FOLDER));
 			}
@@ -800,14 +817,17 @@ namespace Nexus.Client
 				p_vwmErrorMessage = new ViewMessage(String.Format("An error occured while retrieving managed mods: \n\n{0}", ex.Message), null, "Install Log", MessageBoxIcon.Error);
 				return null;
 			}
-			Trace.TraceInformation("Found {0} managed mods.", mrgModRegistry.RegisteredMods.Count);
+
+		    Trace.TraceInformation("Found {0} managed mods.", mrgModRegistry.RegisteredMods.Count);
 			Trace.Unindent();
 
 			Trace.TraceInformation("Initializing Install Log...");
 			Trace.Indent();
 			Trace.TraceInformation("Checking if upgrade is required...");
-			InstallLogUpgrader iluUgrader = new InstallLogUpgrader();
-			string strLogPath = string.Empty;
+
+		    InstallLogUpgrader iluUgrader = new InstallLogUpgrader();
+
+		    string strLogPath = string.Empty;
 
 			try
 			{
@@ -821,7 +841,8 @@ namespace Nexus.Client
 
 			if (!InstallLog.IsLogValid(strLogPath))
 				InstallLog.Restore(strLogPath);
-			if (iluUgrader.NeedsUpgrade(strLogPath))
+
+		    if (iluUgrader.NeedsUpgrade(strLogPath))
 			{
 				if (!iluUgrader.CanUpgrade(strLogPath))
 				{

--- a/NexusClient/Exceptions/GameModeRegistryException.cs
+++ b/NexusClient/Exceptions/GameModeRegistryException.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace Nexus.Client.Exceptions
+{
+    /// <summary>
+    /// Game modes cannot be registered because there are no dlls found in the target path.
+    /// </summary>
+    /// <inheritdoc cref="Exception"/>
+    public class GameModeRegistryException
+        : Exception
+    {
+        public GameModeRegistryException(string path, string message = null)
+            : base(GetMessage(path, message))
+        {
+
+        }
+
+        private static string GetMessage(string path, string message)
+        {
+            var msg = string.IsNullOrWhiteSpace(message) ? null : (". " + message);
+
+            var str = $"No game modes found to register in target path: \"{path}\"" + msg;
+
+            return str;
+        }
+    }
+}

--- a/NexusClient/GameDetectionForm.cs
+++ b/NexusClient/GameDetectionForm.cs
@@ -16,59 +16,34 @@ namespace Nexus.Client
 	/// </summary>
 	public partial class GameDetectionForm : ManagedFontForm
 	{
-		private GameDetectionVM m_vmlViewModel = null;
-		private List<IGameModeDescriptor> lstGameModes = null;
+        #region Properties
+	    private GameDetectionVM _vmlViewModel = null;
 
-		#region Properties
-
-		/// <summary>
-		/// Gets or sets the view model that provides the data and operations for this view.
-		/// </summary>
-		/// <value>The view model that provides the data and operations for this view.</value>
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        /// <summary>
+        /// Gets or sets the view model that provides the data and operations for this view.
+        /// </summary>
+        /// <value>The view model that provides the data and operations for this view.</value>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
 		protected GameDetectionVM ViewModel
 		{
-			get
-			{
-				return m_vmlViewModel;
-			}
-			set
-			{
-				m_vmlViewModel = value;
-				butOK.Enabled = false;
-				m_vmlViewModel.GameDetector.GameResolved += new EventHandler<GameModeDiscoveredEventArgs>(GameDetector_GameResolved);
-				m_vmlViewModel.GameDetector.DisableButOk += new EventHandler<GameModeDiscoveredEventArgs>(GameDetector_DisableButOk);
-				GameModeSearchListViewItem gliGameModeItem = null;
-				lstGameModes = new List<IGameModeDescriptor>(m_vmlViewModel.SupportedGameModes.RegisteredGameModes);
-				for (Int32 i = 0; i < lstGameModes.Count; i++)
-				{
-					gliGameModeItem = new GameModeSearchListViewItem(lstGameModes[i], m_vmlViewModel.GameDetector);
-					gameModeListView1.Controls.Add(gliGameModeItem);
-				}
+			get => _vmlViewModel;
 
-				Size szeMax = Screen.GetWorkingArea(this).Size;
-				Size = new Size((Int32)(szeMax.Width * .9), (Int32)(szeMax.Height * .9));
-				Int32 intWidthOffset = Size.Width - gameModeListView1.ClientSize.Width;
-				Int32 intHeightOffset = Size.Height - gameModeListView1.ClientSize.Height;
-				szeMax = gameModeListView1.ClientSize;
-				Int32 intIdealWidthCount = (Int32)Math.Ceiling(Math.Sqrt(lstGameModes.Count));
-				Int32 intWidth = 0;
-				Int32 intHeigth = 0;
-				do
-				{
-					intWidth = gameModeListView1.PreferredSize.Width / lstGameModes.Count * intIdealWidthCount;
-					intHeigth = gameModeListView1.PreferredSize.Height * (Int32)Math.Ceiling((double)lstGameModes.Count / intIdealWidthCount);
-				} while ((szeMax.Width < intWidth) && (--intIdealWidthCount > 0));
-				if (intHeigth > szeMax.Height)
-				{
-					intWidthOffset += 17;
-					intHeigth = szeMax.Height;
-				}
-				Size = new Size(intWidth + intWidthOffset, intHeigth + intHeightOffset);
+		    set
+			{
+				_vmlViewModel = value;
+
+			    butOK.Enabled = false;
+
+                //Ensure that this is only happening once
+			    _vmlViewModel.GameDetector.GameResolved += GameDetector_GameResolved;
+				_vmlViewModel.GameDetector.DisableButOk += GameDetector_DisableButOk;
+
+			    var lst = new List<IGameModeDescriptor>(_vmlViewModel.SupportedGameModes.RegisteredGameModes);
+
+			    AdjustFormDimentions(lst);
 			}
 		}
-
-		#endregion
+	    #endregion
 
 		#region Constructors
 
@@ -85,7 +60,49 @@ namespace Nexus.Client
 
 		#endregion
 
-		/// <summary>
+	    private void AdjustFormDimentions(List<IGameModeDescriptor> gameModes)
+	    {
+	        foreach (var gm in gameModes)
+	        {
+	            var gliGameModeItem = new GameModeSearchListViewItem(gm, _vmlViewModel.GameDetector);
+
+	            gameModeListView1.Controls.Add(gliGameModeItem);
+	        }
+
+	        var szeMax = Screen.GetWorkingArea(this).Size;
+
+	        Size = new Size((int)(szeMax.Width * .9), (int)(szeMax.Height * .9));
+
+	        var intWidthOffset = Size.Width - gameModeListView1.ClientSize.Width;
+	        var intHeightOffset = Size.Height - gameModeListView1.ClientSize.Height;
+
+	        szeMax = gameModeListView1.ClientSize;
+
+	        var intIdealWidthCount = (int)Math.Ceiling(Math.Sqrt(gameModes.Count));
+
+	        var intWidth = 0;
+	        var intHeigth = 0;
+
+	        do
+	        {
+	            //There is a strong possibility for a DivideByZeroException to be thrown here
+	            intWidth = gameModeListView1.PreferredSize.Width / gameModes.Count * intIdealWidthCount;
+
+	            intHeigth = gameModeListView1.PreferredSize.Height * (int)Math.Ceiling((double)gameModes.Count / intIdealWidthCount);
+	        }
+	        while ((szeMax.Width < intWidth) && (--intIdealWidthCount > 0));
+
+	        if (intHeigth > szeMax.Height)
+	        {
+	            intWidthOffset += 17;
+
+	            intHeigth = szeMax.Height;
+	        }
+
+	        Size = new Size(intWidth + intWidthOffset, intHeigth + intHeightOffset);
+        }
+
+	    /// <summary>
 		/// Handles the <see cref="GameDiscoverer.GameResolved"/> event of the game discoverer.
 		/// </summary>
 		/// <remarks>
@@ -128,7 +145,7 @@ namespace Nexus.Client
 		private void butCancel_Click(object sender, EventArgs e)
 		{
 			DialogResult = DialogResult.None;
-			if (MessageBox.Show(this, String.Format("Cancelling will exit {0}. Are you sure?", ViewModel.EnvironmentInfo.Settings.ModManagerName), "Confirm", MessageBoxButtons.OKCancel, MessageBoxIcon.Question) == DialogResult.OK)
+			if (MessageBox.Show(this, String.Format("Canceling will exit {0}. Are you sure?", ViewModel.EnvironmentInfo.Settings.ModManagerName), "Confirm", MessageBoxButtons.OKCancel, MessageBoxIcon.Question) == DialogResult.OK)
 			{
 				DialogResult = DialogResult.Cancel;
 				ViewModel.Cancel();
@@ -157,7 +174,7 @@ namespace Nexus.Client
 		/// Handles the <see cref="Control.Click"/> event of the quick startup button.
 		/// </summary>
 		/// <remarks>
-		/// Confirms that the users wants to luanch the quick startup.
+		/// Confirms that the users wants to launch the quick startup.
 		/// </remarks>
 		/// <param name="sender">The object that raised the event.</param>
 		/// <param name="e">An <see cref="EventArgs"/> describing the event arguments.</param>

--- a/NexusClient/NexusClient.csproj
+++ b/NexusClient/NexusClient.csproj
@@ -70,6 +70,7 @@
     </Compile>
     <Compile Include="DownloadMonitoring\PurgeDownloadsTask.cs" />
     <Compile Include="EnvironmentInfo.cs" />
+    <Compile Include="Exceptions\GameModeRegistryException.cs" />
     <Compile Include="Extensions\ExtensionMethods.cs" />
     <Compile Include="GameModeSelectionForm.cs">
       <SubType>Form</SubType>


### PR DESCRIPTION
…matter what. Auto creating the folders for Script Types and Game Modes.

If Game Modes are not found throw an exception, if running in debug add a clue as to what is wrong. I did this to stop a DivideByZeroError from occurring in the GameDectionForm.ViewModel property.

If Script Types are not and running in debug add a clue as to what is wrong. It wasn't obvious what the problem was.

GameDetectionForm.ViewModel - cleaned this property up to make it more legible. Consider using a method, this is doing too much, additionally it can throw a DivideByZeroException.