### PR TITLE
Issue 389 - Config file locked

### DIFF
--- a/NexusClient/Settings.cs
+++ b/NexusClient/Settings.cs
@@ -1,39 +1,68 @@
-﻿namespace Nexus.Client.Properties
-{
-    using Nexus.Client.Settings;
+﻿using Nexus.Client.Settings;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
 
+namespace Nexus.Client.Properties
+{
     /// <summary>
     /// This class adds the <see cref="ISettings"/> to the project's <see cref="Properties.Settings"/>
     /// class.
     /// </summary>
     /// <remarks>
-    /// This file should not contain any memebers or properties.
+    /// This file should not contain any members or properties.
     /// </remarks>
     internal sealed partial class Settings : ISettings
 	{
-        private static object _settingsFileLock = new object();
+	    private static readonly object SettingsFileLock = new object();
+	    private const int PauseBetweenAttemptsMilliseconds = 500;
+	    private const int RetryAttempts = 3;
 
-		/// <summary>
-		/// Gets the full name of the mod manager.
-		/// </summary>
-		/// <value>The full name of the mod manager.</value>
-		public string ModManagerName
-		{
-			get
-			{
-				return ProgrammeMetadata.ModManagerName;
-			}
-		}
+        /// <summary>
+        /// Gets the full name of the mod manager.
+        /// </summary>
+        /// <value>The full name of the mod manager.</value>
+        public string ModManagerName => ProgrammeMetadata.ModManagerName;
 
         /// <summary>
         /// A thread-safe call to save the current settings to file.
         /// </summary>
         public override void Save()
         {
-            lock(_settingsFileLock)
+            lock (SettingsFileLock)
             {
-                base.Save();
+                var success = false;
+                
+                /* Realistically a while loop can be used, but in the interest of pessimism it
+                 * is better to err on the side of caution and not potentially create a
+                 * deadlock situation by accident (very small chance of this). */
+                for (var i = 0; i < RetryAttempts; i++)
+                {
+                    /* Normally programming by exception is a bad idea, but when it
+                     * comes to File IO there isn't much of a choice it seems:
+                     * https://stackoverflow.com/questions/876473/is-there-a-way-to-check-if-a-file-is-in-use/876513#876513 */
+
+                    try
+                    {
+                        //Can throw System.IOException due to concurrent file access attempts
+                        base.Save();
+
+                        success = true;
+
+                        break;
+                    }
+                    catch (IOException)
+                    {
+                        //If an IO Exception does occur wait a little between attempts
+                        Thread.Sleep(PauseBetweenAttemptsMilliseconds);
+                    }
+                }
+                
+                if (!success)
+                {
+                    Trace.TraceWarning($"All {RetryAttempts} attempts made to save the configuration file have failed.");
+                }
             }
         }
-	}
+    }
 }


### PR DESCRIPTION
1. Corrected one spelling mistake
2. Changed the lock object to be read only according to MS Singleton recommendations.
3. Changed the lock object name according to ReSharper suggestions.
4. Added a simple retry loop with max attempts
5. Added a Thread.Sleep during IO Exceptions to limit hits to the config file.
6. Added comments to support my changes.
7. If config file isn't saved successfully then adding a Trace Warning. There are numerous attempts to save the config file so I don't think crashing the program is an appropriate reaction.

I made these changes based on [this POC](https://github.com/dyslexicanaboko/dyslexic-code/tree/master/ConcurrentFileAccessTest) I created today. If you want to run it, the idea is to run both console applications simultaneously. They will both try to access the same file and write to it. The console output will show you when there are concurrency errors.

I am pretty confident that these changes will solve our problem even though we cannot actually reproduce it in NMM. Feel free to modify the solution.