### PR TITLE
Bugfix: Lost default game mode

### DIFF
--- a/NexusClient/Bootstrapper.cs
+++ b/NexusClient/Bootstrapper.cs
@@ -120,6 +120,8 @@ namespace Nexus.Client
 					return false;
 				}
 
+			    CheckIfDefaultGameModeIsInstalled(gmrInstalledGames);
+
 				GameModeSelector gmsSelector = new GameModeSelector(gmrSupportedGames, gmrInstalledGames, m_eifEnvironmentInfo);
 				IGameModeFactory gmfGameModeFactory = gmsSelector.SelectGameMode(strRequestedGameMode, booChangeDefaultGameMode);
 				if (gmsSelector.RescanRequested)
@@ -323,6 +325,29 @@ namespace Nexus.Client
 			string str7zPath = Path.Combine(p_eifEnvironmentInfo.ProgrammeInfoDirectory, p_eifEnvironmentInfo.Is64BitProcess ? "7z-64bit.dll" : "7z-32bit.dll");
 			SevenZipCompressor.SetLibraryPath(str7zPath);
 		}
+
+        /// <summary>
+        /// Checks if the default game mode is installed, and clears the setting if that is not the case.
+        /// </summary>
+        /// <param name="installedGames">GameModeRegistry of installed games.</param>
+	    private void CheckIfDefaultGameModeIsInstalled(GameModeRegistry installedGames)
+	    {
+	        var found = false;
+            
+	        foreach (var availableModes in installedGames.RegisteredGameModes)
+	        {
+	            if (availableModes.ModeId.Equals(m_eifEnvironmentInfo.Settings.RememberedGameMode, StringComparison.OrdinalIgnoreCase))
+	            {
+	                found = true;
+	            }
+	        }
+
+	        if (!found)
+	        {
+	            Trace.TraceWarning($"Remembered game mode \"{m_eifEnvironmentInfo.Settings.RememberedGameMode}\" was not found in installed games list, clearing setting.");
+	            m_eifEnvironmentInfo.Settings.RememberGameMode = false;
+	        }
+        }
 
 		#endregion
 


### PR DESCRIPTION
This is a slightly exotic issue, but I'm sure I've seen this mentioned in one of the 233 current issues.

Prerequirements:
* User has selected a default game mode.
* Somehow this game mode is no longer installed.

When the user starts NMM, it will state:
![image](https://user-images.githubusercontent.com/864820/42539810-87445a10-849c-11e8-94be-fd5ae63e0c57.png)

And then promptly shuts down, not giving the user a chance to change their game mode. This means the user will have to find their config file and edit it, or delete it, in order to get into NMM again.

The fix is simple, as seen in 9ded590: As early as we can we compare the remembered game mode against the installed games, and if the default game mode game can't be found, we clear the setting and NMM will prompt the user to select a game mode (or scan for installed games again).


As a bonus, I went through Bootstrapper.cs and followed most of Resharper's recommendations. Leaving the place a little better than I found it :)