### PR TITLE
Sevenzipsharp improvements

### DIFF
--- a/Game Modes/NoMansSky/NoMansSky.csproj
+++ b/Game Modes/NoMansSky/NoMansSky.csproj
@@ -43,7 +43,7 @@
   <ItemGroup>
     <Reference Include="SevenZipSharp, Version=0.64.3890.29348, Culture=neutral, PublicKeyToken=20de82c62b055c88, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\lib\SevenZipSharp.dll</HintPath>
+      <HintPath>..\..\Stage\packages\Squid-Box.SevenZipSharp.1.1.91\lib\net45\SevenZipSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/Mod Formats/FOMod/FOMod.csproj
+++ b/Mod Formats/FOMod/FOMod.csproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <Reference Include="SevenZipSharp, Version=1.1.91.0, Culture=neutral, PublicKeyToken=c8ff6ba0184838bb, processorArchitecture=MSIL">
       <HintPath>..\..\Stage\packages\Squid-Box.SevenZipSharp.1.1.91\lib\net45\SevenZipSharp.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/Mod Formats/OMod/OMod.csproj
+++ b/Mod Formats/OMod/OMod.csproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <Reference Include="SevenZipSharp, Version=1.1.91.0, Culture=neutral, PublicKeyToken=c8ff6ba0184838bb, processorArchitecture=MSIL">
       <HintPath>..\..\Stage\packages\Squid-Box.SevenZipSharp.1.1.91\lib\net45\SevenZipSharp.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/Util/Util.csproj
+++ b/Util/Util.csproj
@@ -43,7 +43,7 @@
   <ItemGroup>
     <Reference Include="SevenZipSharp, Version=0.64.3890.29348, Culture=neutral, PublicKeyToken=20de82c62b055c88, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\lib\SevenZipSharp.dll</HintPath>
+      <HintPath>..\Stage\packages\Squid-Box.SevenZipSharp.1.1.91\lib\net45\SevenZipSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />


### PR DESCRIPTION
Found some issues when trying to work on NMM on my laptop:
* Changed the hint path to SevenZipSharp.dll to the new path.
* Disabled copying SevenZipSharp.dll to the ModFormats folder (only required in the root directory).