### PR TITLE
New settings tab for shell extensions and file/URL association

### DIFF
--- a/NexusClient.Interface/Settings/ISettings.cs
+++ b/NexusClient.Interface/Settings/ISettings.cs
@@ -384,6 +384,16 @@ namespace Nexus.Client.Settings
 		/// <value>The links to help resources.</value>
 		KeyedSettings<string> HelpLinks { get; }
 
+        /// <summary>
+        /// Gets which extensions shall have shell extensions added.
+        /// </summary>
+        KeyedSettings<bool> AddShellExtensions { get; }
+
+        /// <summary>
+        /// Gets or sets whether NMM should be associated with NXM url's.
+        /// </summary>
+        bool AssociateWithUrl { get; set; }
+
 		/// <summary>
 		/// Gets or sets whether to check for updates on startup.
 		/// </summary>

--- a/NexusClient/MainFormVM.cs
+++ b/NexusClient/MainFormVM.cs
@@ -638,15 +638,22 @@ namespace Nexus.Client
 			HelpInfo = new HelpInformation(p_eifEnvironmentInfo);
 
 			GeneralSettingsGroup gsgGeneralSettings = new GeneralSettingsGroup(p_eifEnvironmentInfo);
-			foreach (IModFormat mftFormat in  p_mmgModManager.ModFormats)
-				gsgGeneralSettings.AddFileAssociation(mftFormat.Extension, mftFormat.Name);
+		    var gsgAssociationSettings = new OsSettingsGroup(p_eifEnvironmentInfo);
 
-			ModOptionsSettingsGroup mosModOptions = new ModOptionsSettingsGroup(p_eifEnvironmentInfo);
+		    foreach (IModFormat mftFormat in  p_mmgModManager.ModFormats)
+            {
+                gsgAssociationSettings.AddFileAssociation(mftFormat.Extension, mftFormat.Name);
+            }
 
-			List<ISettingsGroupView> lstSettingGroups = new List<ISettingsGroupView>();
-			lstSettingGroups.Add(new GeneralSettingsPage(gsgGeneralSettings));
-			lstSettingGroups.Add(new ModOptionsPage(mosModOptions));
-			DownloadSettingsGroup dsgDownloadSettings = new DownloadSettingsGroup(p_eifEnvironmentInfo, ModRepository);
+            ModOptionsSettingsGroup mosModOptions = new ModOptionsSettingsGroup(p_eifEnvironmentInfo);
+
+		    List<ISettingsGroupView> lstSettingGroups = new List<ISettingsGroupView>
+		    {
+		        new GeneralSettingsPage(gsgGeneralSettings),
+                new OsSettingsPage(gsgAssociationSettings),
+		        new ModOptionsPage(mosModOptions)
+		    };
+		    DownloadSettingsGroup dsgDownloadSettings = new DownloadSettingsGroup(p_eifEnvironmentInfo, ModRepository);
 			lstSettingGroups.Add(new DownloadSettingsPage(dsgDownloadSettings));
 			
 			if (p_gmdGameMode.SettingsGroupViews != null)

--- a/NexusClient/NexusClient.csproj
+++ b/NexusClient/NexusClient.csproj
@@ -218,6 +218,10 @@
       <DependentUpon>DownloadSettingsPage.cs</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="Settings\UI\OsSettingsPage.resx">
+      <DependentUpon>OsSettingsPage.cs</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="TipsManagement\Balloon.resx" />
     <EmbeddedResource Include="TipsManagement\BalloonVM.resx" />
     <EmbeddedResource Include="TipsManagement\Hooks\WindowsHook.resx" />
@@ -305,8 +309,15 @@
       <DependentUpon>Settings.settings</DependentUpon>
     </Compile>
     <Compile Include="Settings.cs" />
+    <Compile Include="Settings\OsSettingsGroup.cs" />
     <Compile Include="Settings\FileAssociationSetting.cs" />
     <Compile Include="Settings\ShellExtensionUtil.cs" />
+    <Compile Include="Settings\UI\OsSettingsPage.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Settings\UI\OsSettingsPage.Designer.cs">
+      <DependentUpon>OsSettingsPage.cs</DependentUpon>
+    </Compile>
     <Compile Include="Settings\UrlAssociationUtil.cs" />
     <Compile Include="TipsManagement\Balloon.cs">
       <SubType>Form</SubType>

--- a/NexusClient/Properties/Settings.Designer.cs
+++ b/NexusClient/Properties/Settings.Designer.cs
@@ -827,5 +827,35 @@ namespace Nexus.Client.Properties {
                 this["SkyrimSEFirstInstallWarning"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n<KeyedSettingsOfBoolean />")]
+        public global::Nexus.Client.Settings.KeyedSettings<bool> AddShellExtensions
+        {
+            get
+            {
+                return ((global::Nexus.Client.Settings.KeyedSettings<bool>)(this["AddShellExtensions"]));
+            }
+            set
+            {
+                this["AddShellExtensions"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool AssociateWithUrl
+        {
+            get
+            {
+                return ((bool)(this["AssociateWithUrl"]));
+            }
+            set
+            {
+                this["AssociateWithUrl"] = value;
+            }
+        }
     }
 }

--- a/NexusClient/Settings/GeneralSettingsGroup.cs
+++ b/NexusClient/Settings/GeneralSettingsGroup.cs
@@ -18,8 +18,7 @@
 		private bool _scanSubfoldersForMods = true;
 		private bool _overrideLocalModNames = true;
 		private bool _addMissingModInfo = true;
-		private bool _addShellExtensions = true;
-		private bool _associateNxmUrls = true;
+		
 		private bool _checkForUpdatesOnStartup = true;
 	    private bool _checkForTipsOnStartup = true;
 	    private int _updateCheckInterval;
@@ -34,18 +33,6 @@
 		/// </summary>
 		/// <value>The title of the settings group.</value>
 		public override string Title { get; } = "General";
-
-	    /// <summary>
-		/// Gets the enumeration of file types associated with the client.
-		/// </summary>
-		/// <value>Ehe enumeration of file types associated with the client.</value>
-		public IEnumerable<FileAssociationSetting> FileAssociations { get; }
-
-		/// <summary>
-		/// Gets whether or not file associations can be made.
-		/// </summary>
-		/// <value>Whether or not file associations can be made.</value>
-		public bool CanAssociateFiles { get; } = UacUtil.IsElevated;
 
 	    /// <summary>
 		/// Gets or sets whether or not the client should check for new mod versions.
@@ -125,31 +112,7 @@
 			}
 		}
 
-		/// <summary>
-		/// Gets or sets whether the client should integrate with the explorer shell (right-click menu).
-		/// </summary>
-		/// <value>Whether the client should integrate with the explorer shell (right-click menu).</value>
-		public bool AddShellExtensions
-		{
-			get => _addShellExtensions;
-		    set
-			{
-				SetPropertyIfChanged(ref _addShellExtensions, value, () => AddShellExtensions);
-			}
-		}
-
-		/// <summary>
-		/// Gets or sets whether the client should be associated with NXM URLs.
-		/// </summary>
-		/// <value>Whether the client should be associated with NXM URLs.</value>
-		public bool AssociateNxmUrl
-		{
-			get => _associateNxmUrls;
-		    set
-			{
-				SetPropertyIfChanged(ref _associateNxmUrls, value, () => AssociateNxmUrl);
-			}
-		}
+		
 
 		/// <summary>
 		/// Gets or sets whether the client should check for updates on startup.
@@ -239,93 +202,6 @@
 		public GeneralSettingsGroup(IEnvironmentInfo environmentInfo)
 			: base(environmentInfo)
 		{
-			FileAssociations = new List<FileAssociationSetting>();
-		}
-
-		#endregion
-
-		#region File Association
-
-		/// <summary>
-		/// Add a possible client programme file association.
-		/// </summary>
-		/// <param name="extension">The extension to allow to be associated with the client.</param>
-		/// <param name="description">A description of the file type.</param>
-		public void AddFileAssociation(string extension, string description)
-		{
-			((List<FileAssociationSetting>)FileAssociations).Add(new FileAssociationSetting(extension, description, IsAssociated(extension)));
-		}
-
-		/// <summary>
-		/// Determines if the specified file type is associated with the client.
-		/// </summary>
-		/// <param name="extension">The extension of the file type for which it is to be determined
-		/// whether it is associated with the client.</param>
-		/// <returns><c>true</c> if the file type is associated with the client;
-		/// <c>false</c> otherwise.</returns>
-		protected bool IsAssociated(string extension)
-		{
-			if (!extension.StartsWith("."))
-            {
-                extension = "." + extension;
-            }
-
-            var fileId = extension.TrimStart('.').ToUpperInvariant() + "_File_Type";
-
-			var key = Registry.GetValue(@"HKEY_CLASSES_ROOT\" + extension, null, null) as string;
-
-		    return fileId.Equals(key);
-		}
-
-		/// <summary>
-		/// Associates the specifed file type with the client.
-		/// </summary>
-		/// <param name="fileAssociation">The description of the file type association to create.</param>
-		/// <exception cref="InvalidOperationException">Thrown if the user does not have sufficient priviledges
-		/// to create the association.</exception>
-		protected void AssociateFile(FileAssociationSetting fileAssociation)
-		{
-			if (!UacUtil.IsElevated)
-            {
-                throw new InvalidOperationException("You must have administrative privileges to change file associations.");
-            }
-
-            var fileId = fileAssociation.Extension.TrimStart('.').ToUpperInvariant() + "_File_Type";
-
-			try
-			{
-				Registry.SetValue(@"HKEY_CLASSES_ROOT\" + fileAssociation.Extension, null, fileId);
-				Registry.SetValue(@"HKEY_CLASSES_ROOT\" + fileId, null, fileAssociation.Description, RegistryValueKind.String);
-				Registry.SetValue(@"HKEY_CLASSES_ROOT\" + fileId + @"\DefaultIcon", null, Application.ExecutablePath + ",0", RegistryValueKind.String);
-				Registry.SetValue(@"HKEY_CLASSES_ROOT\" + fileId + @"\shell\open\command", null, "\"" + Application.ExecutablePath + "\" \"%1\"", RegistryValueKind.String);
-			}
-			catch (UnauthorizedAccessException)
-			{
-				throw new InvalidOperationException("Something (usually your antivirus) is preventing the program from interacting with the registry and changing the file associations.");
-			}
-		}
-
-		/// <summary>
-		/// Removes the association of the specifed file type with the client.
-		/// </summary>
-		/// <param name="fileAssociation">The description of the file type association to remove.</param>
-		/// <exception cref="InvalidOperationException">Thrown if the user does not have sufficient priviledges
-		/// to remove the association.</exception>
-		protected void UnassociateFile(FileAssociationSetting fileAssociation)
-		{
-			if (!UacUtil.IsElevated)
-            {
-                throw new InvalidOperationException("You must have administrative privileges to change file associations.");
-            }
-
-            var fileId = fileAssociation.Extension.TrimStart('.').ToUpperInvariant() + "_File_Type";
-			var keys = Registry.ClassesRoot.GetSubKeyNames();
-
-		    if (Array.IndexOf(keys, fileId) != -1)
-			{
-				Registry.ClassesRoot.DeleteSubKeyTree(fileId);
-				Registry.ClassesRoot.DeleteSubKeyTree(fileAssociation.Extension);
-			}
 		}
 
 		#endregion
@@ -337,13 +213,9 @@
 		/// </summary>
 		public override void Load()
 		{
-			foreach (var fasFileAssociation in FileAssociations)
-            {
-                fasFileAssociation.IsAssociated = IsAssociated(fasFileAssociation.Extension);
-            }
+			
 
-            AddShellExtensions = ShellExtensionUtil.ReadShellExtensions();
-			AssociateNxmUrl = UrlAssociationUtil.IsUrlAssociated("nxm");
+            
 			CheckForNewMods = EnvironmentInfo.Settings.CheckForNewModVersions;
 			ModVersionsCheckInterval = EnvironmentInfo.Settings.ModVersionsCheckInterval;
 			AddMissingModInfo = EnvironmentInfo.Settings.AddMissingInfoToMods;
@@ -367,45 +239,6 @@
 		/// <c>false</c> otherwise.</returns>
 		public override bool Save()
 		{
-			if (UacUtil.IsElevated)
-			{
-                foreach (var fasFileAssociation in FileAssociations)
-                {
-                    if (fasFileAssociation.IsAssociated)
-                    {
-                        AssociateFile(fasFileAssociation);
-                    }
-                    else
-                    {
-                        UnassociateFile(fasFileAssociation);
-                    }
-                }
-
-                if (AssociateNxmUrl)
-                {
-                    UrlAssociationUtil.AssociateUrl("nxm", "Nexus Mod");
-                }
-                else
-                {
-                    UrlAssociationUtil.UnassociateUrl("nxm");
-                }
-
-                if (AddShellExtensions)
-                {
-                    if (!ShellExtensionUtil.AddShellExtensions())
-                    {
-                        MessageBox.Show("Couldn't add shell extensions.\nCheck TraceLog for more info.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error, MessageBoxDefaultButton.Button1);
-                    }
-                }
-                else
-                {
-                    if (!ShellExtensionUtil.RemoveShellExtensions())
-                    {
-                        MessageBox.Show("Couldn't remove shell extensions.\nCheck TraceLog for more info.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error, MessageBoxDefaultButton.Button1);
-                    }
-				}
-			}
-
 			EnvironmentInfo.Settings.CheckForNewModVersions = CheckForNewMods;
 			EnvironmentInfo.Settings.ModVersionsCheckInterval = ModVersionsCheckInterval;
 			EnvironmentInfo.Settings.AddMissingInfoToMods = AddMissingModInfo;

--- a/NexusClient/Settings/OsSettingsGroup.cs
+++ b/NexusClient/Settings/OsSettingsGroup.cs
@@ -135,6 +135,38 @@
             AddShellExtensionZip = EnvironmentInfo.Settings.AddShellExtensions["zip"];
             AddShellExtensionRar = EnvironmentInfo.Settings.AddShellExtensions["rar"];
             AddShellExtension7z = EnvironmentInfo.Settings.AddShellExtensions["7z"];
+
+            if (EnvironmentInfo.Settings.AssociateWithUrl && !UrlAssociationUtil.IsUrlAssociated("nxm"))
+            {
+                if (UacUtil.IsElevated)
+                {
+                    var reply = MessageBox.Show("NXM URL association has been removed by some other process.\n\n" +
+                                                "Do you want to restore it?",
+                        "Association removed by another process", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+
+                    if (reply == DialogResult.Yes)
+                    {
+                        UrlAssociationUtil.AssociateUrl("nxm", "Nexus Mod");
+                    }
+                    else
+                    {
+                        EnvironmentInfo.Settings.AssociateWithUrl = false;
+                    }
+                }
+                else
+                {
+                    var removeSetting = MessageBox.Show("NXM URL association has been removed by some other process.\n\n" +
+                                                        $"If you want to restore it you have to run {EnvironmentInfo.Settings.ModManagerName} as Administrator.\n\n" +
+                                                        "Do you want to disable the setting instead?",
+                        "Association removed by another process", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+
+                    if (removeSetting == DialogResult.Yes)
+                    {
+                        EnvironmentInfo.Settings.AssociateWithUrl = false;
+                    }
+                }
+            }
+
             AssociateNxmUrl = UrlAssociationUtil.IsUrlAssociated("nxm");
         }
 

--- a/NexusClient/Settings/OsSettingsGroup.cs
+++ b/NexusClient/Settings/OsSettingsGroup.cs
@@ -1,0 +1,196 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+using Microsoft.Win32;
+using Nexus.Client.Util;
+
+namespace Nexus.Client.Settings
+{
+    public class OsSettingsGroup : SettingsGroup
+    {
+        private bool _addShellExtensions = true;
+        private bool _associateNxmUrls = true;
+
+        public OsSettingsGroup(IEnvironmentInfo p_eifEnvironmentInfo) : base(p_eifEnvironmentInfo)
+        {
+            FileAssociations = new List<FileAssociationSetting>();
+        }
+
+        /// <summary>
+        /// Gets the enumeration of file types associated with the client.
+        /// </summary>
+        /// <value>Ehe enumeration of file types associated with the client.</value>
+        public IEnumerable<FileAssociationSetting> FileAssociations { get; }
+
+        /// <summary>
+        /// Gets whether or not file associations can be made.
+        /// </summary>
+        /// <value>Whether or not file associations can be made.</value>
+        public bool CanAssociateFiles { get; } = UacUtil.IsElevated;
+
+        /// <summary>
+        /// Gets or sets whether the client should integrate with the explorer shell (right-click menu).
+        /// </summary>
+        /// <value>Whether the client should integrate with the explorer shell (right-click menu).</value>
+        public bool AddShellExtensions
+        {
+            get => _addShellExtensions;
+            set
+            {
+                SetPropertyIfChanged(ref _addShellExtensions, value, () => AddShellExtensions);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets whether the client should be associated with NXM URLs.
+        /// </summary>
+        /// <value>Whether the client should be associated with NXM URLs.</value>
+        public bool AssociateNxmUrl
+        {
+            get => _associateNxmUrls;
+            set
+            {
+                SetPropertyIfChanged(ref _associateNxmUrls, value, () => AssociateNxmUrl);
+            }
+        }
+
+        public override string Title => "OS Settings";
+
+        public override void Load()
+        {
+            foreach (var fasFileAssociation in FileAssociations)
+            {
+                fasFileAssociation.IsAssociated = IsAssociated(fasFileAssociation.Extension);
+            }
+
+            AddShellExtensions = ShellExtensionUtil.ReadShellExtensions();
+            AssociateNxmUrl = UrlAssociationUtil.IsUrlAssociated("nxm");
+        }
+
+        public override bool Save()
+        {
+            if (UacUtil.IsElevated)
+            {
+                foreach (var fasFileAssociation in FileAssociations)
+                {
+                    if (fasFileAssociation.IsAssociated)
+                    {
+                        AssociateFile(fasFileAssociation);
+                    }
+                    else
+                    {
+                        UnassociateFile(fasFileAssociation);
+                    }
+                }
+
+                if (AssociateNxmUrl)
+                {
+                    UrlAssociationUtil.AssociateUrl("nxm", "Nexus Mod");
+                }
+                else
+                {
+                    UrlAssociationUtil.UnassociateUrl("nxm");
+                }
+
+                if (AddShellExtensions)
+                {
+                    if (!ShellExtensionUtil.AddShellExtensions())
+                    {
+                        MessageBox.Show("Couldn't add shell extensions.\nCheck TraceLog for more info.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error, MessageBoxDefaultButton.Button1);
+                    }
+                }
+                else
+                {
+                    if (!ShellExtensionUtil.RemoveShellExtensions())
+                    {
+                        MessageBox.Show("Couldn't remove shell extensions.\nCheck TraceLog for more info.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error, MessageBoxDefaultButton.Button1);
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Add a possible client programme file association.
+        /// </summary>
+        /// <param name="extension">The extension to allow to be associated with the client.</param>
+        /// <param name="description">A description of the file type.</param>
+        public void AddFileAssociation(string extension, string description)
+        {
+            ((List<FileAssociationSetting>)FileAssociations).Add(new FileAssociationSetting(extension, description, IsAssociated(extension)));
+        }
+
+        /// <summary>
+        /// Determines if the specified file type is associated with the client.
+        /// </summary>
+        /// <param name="extension">The extension of the file type for which it is to be determined
+        /// whether it is associated with the client.</param>
+        /// <returns><c>true</c> if the file type is associated with the client;
+        /// <c>false</c> otherwise.</returns>
+        protected bool IsAssociated(string extension)
+        {
+            if (!extension.StartsWith("."))
+            {
+                extension = "." + extension;
+            }
+
+            var fileId = extension.TrimStart('.').ToUpperInvariant() + "_File_Type";
+
+            var key = Registry.GetValue(@"HKEY_CLASSES_ROOT\" + extension, null, null) as string;
+
+            return fileId.Equals(key);
+        }
+
+        /// <summary>
+        /// Associates the specifed file type with the client.
+        /// </summary>
+        /// <param name="fileAssociation">The description of the file type association to create.</param>
+        /// <exception cref="InvalidOperationException">Thrown if the user does not have sufficient priviledges
+        /// to create the association.</exception>
+        protected void AssociateFile(FileAssociationSetting fileAssociation)
+        {
+            if (!UacUtil.IsElevated)
+            {
+                throw new InvalidOperationException("You must have administrative privileges to change file associations.");
+            }
+
+            var fileId = fileAssociation.Extension.TrimStart('.').ToUpperInvariant() + "_File_Type";
+
+            try
+            {
+                Registry.SetValue(@"HKEY_CLASSES_ROOT\" + fileAssociation.Extension, null, fileId);
+                Registry.SetValue(@"HKEY_CLASSES_ROOT\" + fileId, null, fileAssociation.Description, RegistryValueKind.String);
+                Registry.SetValue(@"HKEY_CLASSES_ROOT\" + fileId + @"\DefaultIcon", null, Application.ExecutablePath + ",0", RegistryValueKind.String);
+                Registry.SetValue(@"HKEY_CLASSES_ROOT\" + fileId + @"\shell\open\command", null, "\"" + Application.ExecutablePath + "\" \"%1\"", RegistryValueKind.String);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                throw new InvalidOperationException("Something (usually your antivirus) is preventing the program from interacting with the registry and changing the file associations.");
+            }
+        }
+
+        /// <summary>
+        /// Removes the association of the specifed file type with the client.
+        /// </summary>
+        /// <param name="fileAssociation">The description of the file type association to remove.</param>
+        /// <exception cref="InvalidOperationException">Thrown if the user does not have sufficient priviledges
+        /// to remove the association.</exception>
+        protected void UnassociateFile(FileAssociationSetting fileAssociation)
+        {
+            if (!UacUtil.IsElevated)
+            {
+                throw new InvalidOperationException("You must have administrative privileges to change file associations.");
+            }
+
+            var fileId = fileAssociation.Extension.TrimStart('.').ToUpperInvariant() + "_File_Type";
+            var keys = Registry.ClassesRoot.GetSubKeyNames();
+
+            if (Array.IndexOf(keys, fileId) != -1)
+            {
+                Registry.ClassesRoot.DeleteSubKeyTree(fileId);
+                Registry.ClassesRoot.DeleteSubKeyTree(fileAssociation.Extension);
+            }
+        }
+    }
+}

--- a/NexusClient/Settings/UI/GeneralSettingsPage.Designer.cs
+++ b/NexusClient/Settings/UI/GeneralSettingsPage.Designer.cs
@@ -28,306 +28,242 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.components = new System.ComponentModel.Container();
-			this.flpGeneral = new System.Windows.Forms.FlowLayoutPanel();
-			this.gbxAssociations = new System.Windows.Forms.GroupBox();
-			this.flpFileAssociations = new System.Windows.Forms.FlowLayoutPanel();
-			this.ckbShellExtensions = new System.Windows.Forms.CheckBox();
-			this.ckbAssociateURL = new System.Windows.Forms.CheckBox();
-			this.groupBox5 = new System.Windows.Forms.GroupBox();
-			this.ckbScanSubfolders = new System.Windows.Forms.CheckBox();
-			this.ckbOverrideLocalNames = new System.Windows.Forms.CheckBox();
-			this.ckbAddMissingInfo = new System.Windows.Forms.CheckBox();
-			this.ckbCheckForUpdates = new System.Windows.Forms.CheckBox();
-			this.ckbShowSidePanel = new System.Windows.Forms.CheckBox();
-			this.ckbSkipReadmeFiles = new System.Windows.Forms.CheckBox();
-			this.ckbHideModUpdateWarningIcon = new System.Windows.Forms.CheckBox();
-			this.cbxProgramUpdateCheckInterval = new System.Windows.Forms.ComboBox();
-			this.ttpTip = new System.Windows.Forms.ToolTip(this.components);
-			this.ckbCloseManagerAfterGameLaunch = new System.Windows.Forms.CheckBox();
-			this.lblTraceLogDirectory = new System.Windows.Forms.Label();
-			this.tbxTraceLogDirectory = new System.Windows.Forms.TextBox();
-			this.butSelectTraceLogDirectory = new System.Windows.Forms.Button();
-			this.lblTempPathDirectory = new System.Windows.Forms.Label();
-			this.lblTempPathWarning = new System.Windows.Forms.Label();
-			this.tbxTempPathDirectory = new System.Windows.Forms.TextBox();
-			this.butSelectTempPathDirectory = new System.Windows.Forms.Button();
-			this.fbdTraceLogDirectory = new System.Windows.Forms.FolderBrowserDialog();
-			this.fbdTempPathDirectory = new System.Windows.Forms.FolderBrowserDialog();
-			this.flpGeneral.SuspendLayout();
-			this.gbxAssociations.SuspendLayout();
-			this.flpFileAssociations.SuspendLayout();
-			this.groupBox5.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// flpGeneral
-			// 
-			this.flpGeneral.AutoScroll = true;
-			this.flpGeneral.Controls.Add(this.gbxAssociations);
-			this.flpGeneral.Controls.Add(this.groupBox5);
-			this.flpGeneral.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.flpGeneral.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
-			this.flpGeneral.Location = new System.Drawing.Point(0, 0);
-			this.flpGeneral.Name = "flpGeneral";
-			this.flpGeneral.Size = new System.Drawing.Size(398, 294);
-			this.flpGeneral.TabIndex = 25;
-			this.flpGeneral.WrapContents = false;
-			this.flpGeneral.MouseMove += new System.Windows.Forms.MouseEventHandler(this.flpGeneral_MouseMove);
-			this.flpGeneral.MouseHover += new System.EventHandler(this.flpGeneral_MouseHover);
-			// 
-			// gbxAssociations
-			// 
-			this.gbxAssociations.AutoSize = true;
-			this.gbxAssociations.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.gbxAssociations.Controls.Add(this.flpFileAssociations);
-			this.gbxAssociations.Location = new System.Drawing.Point(3, 3);
-			this.gbxAssociations.MinimumSize = new System.Drawing.Size(368, 0);
-			this.gbxAssociations.Name = "gbxAssociations";
-			this.gbxAssociations.Size = new System.Drawing.Size(368, 71);
-			this.gbxAssociations.TabIndex = 22;
-			this.gbxAssociations.TabStop = false;
-			this.gbxAssociations.Text = "Associations";
-			// 
-			// flpFileAssociations
-			// 
-			this.flpFileAssociations.AutoSize = true;
-			this.flpFileAssociations.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.flpFileAssociations.Controls.Add(this.ckbShellExtensions);
-			this.flpFileAssociations.Controls.Add(this.ckbAssociateURL);
-			this.flpFileAssociations.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.flpFileAssociations.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
-			this.flpFileAssociations.Location = new System.Drawing.Point(3, 16);
-			this.flpFileAssociations.Name = "flpFileAssociations";
-			this.flpFileAssociations.Padding = new System.Windows.Forms.Padding(10, 3, 3, 3);
-			this.flpFileAssociations.Size = new System.Drawing.Size(362, 52);
-			this.flpFileAssociations.TabIndex = 4;
-			// 
-			// ckbShellExtensions
-			// 
-			this.ckbShellExtensions.AutoSize = true;
-			this.ckbShellExtensions.Location = new System.Drawing.Point(13, 6);
-			this.ckbShellExtensions.Name = "ckbShellExtensions";
-			this.ckbShellExtensions.Size = new System.Drawing.Size(231, 17);
-			this.ckbShellExtensions.TabIndex = 3;
-			this.ckbShellExtensions.Text = "Add shell extensions for supported file types";
-			this.ckbShellExtensions.UseVisualStyleBackColor = true;
-			// 
-			// ckbAssociateURL
-			// 
-			this.ckbAssociateURL.AutoSize = true;
-			this.ckbAssociateURL.Location = new System.Drawing.Point(13, 29);
-			this.ckbAssociateURL.Name = "ckbAssociateURL";
-			this.ckbAssociateURL.Size = new System.Drawing.Size(151, 17);
-			this.ckbAssociateURL.TabIndex = 6;
-			this.ckbAssociateURL.Text = "Associate with NXM URLs";
-			this.ckbAssociateURL.UseVisualStyleBackColor = true;
-			// 
-			// groupBox5
-			// 
-			this.groupBox5.Controls.Add(this.ckbCloseManagerAfterGameLaunch);
-			this.groupBox5.Controls.Add(this.ckbScanSubfolders);
-			this.groupBox5.Controls.Add(this.ckbOverrideLocalNames);
-			this.groupBox5.Controls.Add(this.ckbAddMissingInfo);
-			this.groupBox5.Controls.Add(this.ckbCheckForUpdates);
-			this.groupBox5.Controls.Add(this.cbxProgramUpdateCheckInterval);
-			this.groupBox5.Controls.Add(this.ckbShowSidePanel);
-			this.groupBox5.Controls.Add(this.ckbSkipReadmeFiles);
-			this.groupBox5.Controls.Add(this.ckbHideModUpdateWarningIcon);
-			this.groupBox5.Controls.Add(this.butSelectTraceLogDirectory);
-			this.groupBox5.Controls.Add(this.tbxTraceLogDirectory);
-			this.groupBox5.Controls.Add(this.lblTraceLogDirectory);
-			this.groupBox5.Controls.Add(this.butSelectTempPathDirectory);
-			this.groupBox5.Controls.Add(this.tbxTempPathDirectory);
-			this.groupBox5.Controls.Add(this.lblTempPathDirectory);
-			this.groupBox5.Controls.Add(this.lblTempPathWarning);
-			this.groupBox5.Location = new System.Drawing.Point(3, 80);
-			this.groupBox5.Name = "groupBox5";
-			this.groupBox5.Size = new System.Drawing.Size(368, 300);
-			this.groupBox5.TabIndex = 23;
-			this.groupBox5.TabStop = false;
-			this.groupBox5.Text = "Options";
-			// 
-			// ckbScanSubfolders
-			// 
-			this.ckbScanSubfolders.AutoSize = true;
-			this.ckbScanSubfolders.Location = new System.Drawing.Point(16, 88);
-			this.ckbScanSubfolders.Name = "ckbScanSubfolders";
-			this.ckbScanSubfolders.Size = new System.Drawing.Size(217, 17);
-			this.ckbScanSubfolders.TabIndex = 5;
-			this.ckbScanSubfolders.Text = "Scan Mods directory subfolders for mods";
-			this.ckbScanSubfolders.UseVisualStyleBackColor = true;
-			// 
-			// ckbOverrideLocalNames
-			// 
-			this.ckbOverrideLocalNames.AutoSize = true;
-			this.ckbOverrideLocalNames.Location = new System.Drawing.Point(16, 180);
-			this.ckbOverrideLocalNames.Name = "ckbOverrideLocalNames";
-			this.ckbOverrideLocalNames.Size = new System.Drawing.Size(217, 17);
-			this.ckbOverrideLocalNames.TabIndex = 5;
-			this.ckbOverrideLocalNames.Text = "Allow NMM to update mod names";
-			this.ckbOverrideLocalNames.UseVisualStyleBackColor = true;
-			// 
-			// ckbAddMissingInfo
-			// 
-			this.ckbAddMissingInfo.AutoSize = true;
-			this.ckbAddMissingInfo.Location = new System.Drawing.Point(16, 65);
-			this.ckbAddMissingInfo.Name = "ckbAddMissingInfo";
-			this.ckbAddMissingInfo.Size = new System.Drawing.Size(143, 17);
-			this.ckbAddMissingInfo.TabIndex = 4;
-			this.ckbAddMissingInfo.Text = "Add missing info to Mods";
-			this.ckbAddMissingInfo.UseVisualStyleBackColor = true;
-			// 
-			// ckbCheckForUpdates
-			// 
-			this.ckbCheckForUpdates.AutoSize = true;
-			this.ckbCheckForUpdates.Location = new System.Drawing.Point(16, 19);
-			this.ckbCheckForUpdates.Name = "ckbCheckForUpdates";
-			this.ckbCheckForUpdates.Size = new System.Drawing.Size(163, 17);
-			this.ckbCheckForUpdates.TabIndex = 0;
-			this.ckbCheckForUpdates.Text = "Check for updates on startup - interval (in days):";
-			this.ckbCheckForUpdates.UseVisualStyleBackColor = true;
-			// 
-			// cbxProgramUpdateCheckInterval
-			// 
-			this.cbxProgramUpdateCheckInterval.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.cbxProgramUpdateCheckInterval.FormattingEnabled = true;
-			this.cbxProgramUpdateCheckInterval.Location = new System.Drawing.Point(267, 17);
-			this.cbxProgramUpdateCheckInterval.Name = "cbxProgramUpdateCheckInterval";
-			this.cbxProgramUpdateCheckInterval.Size = new System.Drawing.Size(64, 21);
-			this.cbxProgramUpdateCheckInterval.TabIndex = 1;
-			// 
-			// ckbCloseManagerAfterGameLaunch
-			// 
-			this.ckbCloseManagerAfterGameLaunch.AutoSize = true;
-			this.ckbCloseManagerAfterGameLaunch.Location = new System.Drawing.Point(16, 111);
-			this.ckbCloseManagerAfterGameLaunch.Name = "ckbCloseManagerAfterGameLaunch";
-			this.ckbCloseManagerAfterGameLaunch.Size = new System.Drawing.Size(171, 17);
-			this.ckbCloseManagerAfterGameLaunch.TabIndex = 7;
-			this.ckbCloseManagerAfterGameLaunch.Text = "Close {0} after launching game";
-			this.ckbCloseManagerAfterGameLaunch.UseVisualStyleBackColor = true;
-			// 
-			// ckbShowSidePanel
-			// 
-			this.ckbShowSidePanel.AutoSize = true;
-			this.ckbShowSidePanel.Location = new System.Drawing.Point(16, 134);
-			this.ckbShowSidePanel.Name = "ckbShowSidePanel";
-			this.ckbShowSidePanel.Size = new System.Drawing.Size(217, 17);
-			this.ckbShowSidePanel.TabIndex = 8;
-			this.ckbShowSidePanel.Text = "Enable mod info side panel";
-			this.ckbShowSidePanel.UseVisualStyleBackColor = true;
-			// 
-			// ckbSkipReadmeFiles
-			// 
-			this.ckbSkipReadmeFiles.AutoSize = true;
-			this.ckbSkipReadmeFiles.Location = new System.Drawing.Point(16, 42);
-			this.ckbSkipReadmeFiles.Name = "ckbSkipReadmeFiles";
-			this.ckbSkipReadmeFiles.Size = new System.Drawing.Size(217, 17);
-			this.ckbSkipReadmeFiles.TabIndex = 8;
-			this.ckbSkipReadmeFiles.Text = "Don't extract ReadMe files";
-			this.ckbSkipReadmeFiles.UseVisualStyleBackColor = true;
-			// 
-			// ckbHideModUpdateWarningIcon
-			// 
-			this.ckbHideModUpdateWarningIcon.AutoSize = true;
-			this.ckbHideModUpdateWarningIcon.Location = new System.Drawing.Point(16, 157);
-			this.ckbHideModUpdateWarningIcon.Name = "ckbHideModUpdateWarningIcon";
-			this.ckbHideModUpdateWarningIcon.Size = new System.Drawing.Size(217, 17);
-			this.ckbHideModUpdateWarningIcon.TabIndex = 8;
-			this.ckbHideModUpdateWarningIcon.Text = "Hide Mod Update Warning Icon ";
-			this.ckbHideModUpdateWarningIcon.UseVisualStyleBackColor = true;
-			// 
-			// lblTraceLogDirectory
-			// 
-			this.lblTraceLogDirectory.AutoSize = true;
-			this.lblTraceLogDirectory.Location = new System.Drawing.Point(16, 205);
-			this.lblTraceLogDirectory.Name = "lblTraceLogDirectory";
-			this.lblTraceLogDirectory.Size = new System.Drawing.Size(73, 13);
-			this.lblTraceLogDirectory.TabIndex = 3;
-			this.lblTraceLogDirectory.Text = "TraceLog Directory:";
-			// 
-			// tbxTraceLogDirectory
-			// 
-			this.tbxTraceLogDirectory.Location = new System.Drawing.Point(16, 220);
-			this.tbxTraceLogDirectory.Name = "tbxTraceLogDirectory";
-			this.tbxTraceLogDirectory.Size = new System.Drawing.Size(290, 20);
-			this.tbxTraceLogDirectory.TabIndex = 1;
-			// 
-			// butSelectTraceLogDirectory
-			// 
-			this.butSelectTraceLogDirectory.AutoSize = true;
-			this.butSelectTraceLogDirectory.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.butSelectTraceLogDirectory.Location = new System.Drawing.Point(320, 220);
-			this.butSelectTraceLogDirectory.Name = "butSelectTraceLogDirectory";
-			this.butSelectTraceLogDirectory.Size = new System.Drawing.Size(26, 23);
-			this.butSelectTraceLogDirectory.TabIndex = 2;
-			this.butSelectTraceLogDirectory.Text = "...";
-			this.butSelectTraceLogDirectory.UseVisualStyleBackColor = true;
-			this.butSelectTraceLogDirectory.Click += new System.EventHandler(this.butSelectTraceLogDirectory_Click);
-			// 
-			// butSelectTempPathDirectory
-			// 
-			this.butSelectTempPathDirectory.AutoSize = true;
-			this.butSelectTempPathDirectory.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-			this.butSelectTempPathDirectory.Location = new System.Drawing.Point(320, 275);
-			this.butSelectTempPathDirectory.Name = "butSelectTempPathDirectory";
-			this.butSelectTempPathDirectory.Size = new System.Drawing.Size(26, 23);
-			this.butSelectTempPathDirectory.TabIndex = 2;
-			this.butSelectTempPathDirectory.Text = "...";
-			this.butSelectTempPathDirectory.UseVisualStyleBackColor = true;
-			this.butSelectTempPathDirectory.Click += new System.EventHandler(this.butSelectTempPathDirectory_Click);
-			// 
-			// lblTempPathDirectory
-			// 
-			this.lblTempPathDirectory.AutoSize = true;
-			this.lblTempPathDirectory.Location = new System.Drawing.Point(16, 245);
-			this.lblTempPathDirectory.Name = "lblTempPathDirectory";
-			this.lblTempPathDirectory.Size = new System.Drawing.Size(73, 13);
-			this.lblTempPathDirectory.TabIndex = 3;
-			this.lblTempPathDirectory.Text = "Temporary Path Directory: (Folder must be named \"Temp\")";
-			// 
-			// lblTempPathWarning
-			// 
-			this.lblTempPathWarning.AutoSize = true;
-			this.lblTempPathWarning.Location = new System.Drawing.Point(16, 260);
-			this.lblTempPathWarning.Name = "lblTempPathDirectory";
-			this.lblTempPathWarning.Size = new System.Drawing.Size(73, 13);
-			this.lblTempPathWarning.TabIndex = 4;
-			this.lblTempPathWarning.Text = "* Requires a restart to be applied!";
-			// 
-			// tbxTempPathDirectory
-			// 
-			this.tbxTempPathDirectory.Location = new System.Drawing.Point(16, 275);
-			this.tbxTempPathDirectory.Name = "tbxTempPathDirectory";
-			this.tbxTempPathDirectory.Size = new System.Drawing.Size(290, 20);
-			this.tbxTempPathDirectory.TabIndex = 1;
-			this.tbxTempPathDirectory.LostFocus += new System.EventHandler(tbxTempPathDirectory_LostFocus);
-			this.tbxTempPathDirectory.Enabled = false;
-			// 
-			// GeneralSettingsPage
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.Controls.Add(this.flpGeneral);
-			this.Name = "GeneralSettingsPage";
-			this.Size = new System.Drawing.Size(398, 294);
-			this.flpGeneral.ResumeLayout(false);
-			this.flpGeneral.PerformLayout();
-			this.gbxAssociations.ResumeLayout(false);
-			this.gbxAssociations.PerformLayout();
-			this.flpFileAssociations.ResumeLayout(false);
-			this.flpFileAssociations.PerformLayout();
-			this.groupBox5.ResumeLayout(false);
-			this.groupBox5.PerformLayout();
-			this.ResumeLayout(false);
+            this.components = new System.ComponentModel.Container();
+            this.flpGeneral = new System.Windows.Forms.FlowLayoutPanel();
+            this.groupBox5 = new System.Windows.Forms.GroupBox();
+            this.ckbCloseManagerAfterGameLaunch = new System.Windows.Forms.CheckBox();
+            this.ckbScanSubfolders = new System.Windows.Forms.CheckBox();
+            this.ckbOverrideLocalNames = new System.Windows.Forms.CheckBox();
+            this.ckbAddMissingInfo = new System.Windows.Forms.CheckBox();
+            this.ckbCheckForUpdates = new System.Windows.Forms.CheckBox();
+            this.cbxProgramUpdateCheckInterval = new System.Windows.Forms.ComboBox();
+            this.ckbShowSidePanel = new System.Windows.Forms.CheckBox();
+            this.ckbSkipReadmeFiles = new System.Windows.Forms.CheckBox();
+            this.ckbHideModUpdateWarningIcon = new System.Windows.Forms.CheckBox();
+            this.butSelectTraceLogDirectory = new System.Windows.Forms.Button();
+            this.tbxTraceLogDirectory = new System.Windows.Forms.TextBox();
+            this.lblTraceLogDirectory = new System.Windows.Forms.Label();
+            this.butSelectTempPathDirectory = new System.Windows.Forms.Button();
+            this.tbxTempPathDirectory = new System.Windows.Forms.TextBox();
+            this.lblTempPathDirectory = new System.Windows.Forms.Label();
+            this.lblTempPathWarning = new System.Windows.Forms.Label();
+            this.ttpTip = new System.Windows.Forms.ToolTip(this.components);
+            this.fbdTraceLogDirectory = new System.Windows.Forms.FolderBrowserDialog();
+            this.fbdTempPathDirectory = new System.Windows.Forms.FolderBrowserDialog();
+            this.flpGeneral.SuspendLayout();
+            this.groupBox5.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // flpGeneral
+            // 
+            this.flpGeneral.AutoScroll = true;
+            this.flpGeneral.Controls.Add(this.groupBox5);
+            this.flpGeneral.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flpGeneral.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            this.flpGeneral.Location = new System.Drawing.Point(0, 0);
+            this.flpGeneral.Name = "flpGeneral";
+            this.flpGeneral.Size = new System.Drawing.Size(398, 294);
+            this.flpGeneral.TabIndex = 25;
+            this.flpGeneral.WrapContents = false;
+            // 
+            // groupBox5
+            // 
+            this.groupBox5.Controls.Add(this.ckbCloseManagerAfterGameLaunch);
+            this.groupBox5.Controls.Add(this.ckbScanSubfolders);
+            this.groupBox5.Controls.Add(this.ckbOverrideLocalNames);
+            this.groupBox5.Controls.Add(this.ckbAddMissingInfo);
+            this.groupBox5.Controls.Add(this.ckbCheckForUpdates);
+            this.groupBox5.Controls.Add(this.cbxProgramUpdateCheckInterval);
+            this.groupBox5.Controls.Add(this.ckbShowSidePanel);
+            this.groupBox5.Controls.Add(this.ckbSkipReadmeFiles);
+            this.groupBox5.Controls.Add(this.ckbHideModUpdateWarningIcon);
+            this.groupBox5.Controls.Add(this.butSelectTraceLogDirectory);
+            this.groupBox5.Controls.Add(this.tbxTraceLogDirectory);
+            this.groupBox5.Controls.Add(this.lblTraceLogDirectory);
+            this.groupBox5.Controls.Add(this.butSelectTempPathDirectory);
+            this.groupBox5.Controls.Add(this.tbxTempPathDirectory);
+            this.groupBox5.Controls.Add(this.lblTempPathDirectory);
+            this.groupBox5.Controls.Add(this.lblTempPathWarning);
+            this.groupBox5.Location = new System.Drawing.Point(3, 3);
+            this.groupBox5.Name = "groupBox5";
+            this.groupBox5.Size = new System.Drawing.Size(368, 300);
+            this.groupBox5.TabIndex = 23;
+            this.groupBox5.TabStop = false;
+            this.groupBox5.Text = "Options";
+            // 
+            // ckbCloseManagerAfterGameLaunch
+            // 
+            this.ckbCloseManagerAfterGameLaunch.AutoSize = true;
+            this.ckbCloseManagerAfterGameLaunch.Location = new System.Drawing.Point(16, 111);
+            this.ckbCloseManagerAfterGameLaunch.Name = "ckbCloseManagerAfterGameLaunch";
+            this.ckbCloseManagerAfterGameLaunch.Size = new System.Drawing.Size(171, 17);
+            this.ckbCloseManagerAfterGameLaunch.TabIndex = 7;
+            this.ckbCloseManagerAfterGameLaunch.Text = "Close {0} after launching game";
+            this.ckbCloseManagerAfterGameLaunch.UseVisualStyleBackColor = true;
+            // 
+            // ckbScanSubfolders
+            // 
+            this.ckbScanSubfolders.AutoSize = true;
+            this.ckbScanSubfolders.Location = new System.Drawing.Point(16, 88);
+            this.ckbScanSubfolders.Name = "ckbScanSubfolders";
+            this.ckbScanSubfolders.Size = new System.Drawing.Size(217, 17);
+            this.ckbScanSubfolders.TabIndex = 5;
+            this.ckbScanSubfolders.Text = "Scan Mods directory subfolders for mods";
+            this.ckbScanSubfolders.UseVisualStyleBackColor = true;
+            // 
+            // ckbOverrideLocalNames
+            // 
+            this.ckbOverrideLocalNames.AutoSize = true;
+            this.ckbOverrideLocalNames.Location = new System.Drawing.Point(16, 180);
+            this.ckbOverrideLocalNames.Name = "ckbOverrideLocalNames";
+            this.ckbOverrideLocalNames.Size = new System.Drawing.Size(185, 17);
+            this.ckbOverrideLocalNames.TabIndex = 5;
+            this.ckbOverrideLocalNames.Text = "Allow NMM to update mod names";
+            this.ckbOverrideLocalNames.UseVisualStyleBackColor = true;
+            // 
+            // ckbAddMissingInfo
+            // 
+            this.ckbAddMissingInfo.AutoSize = true;
+            this.ckbAddMissingInfo.Location = new System.Drawing.Point(16, 65);
+            this.ckbAddMissingInfo.Name = "ckbAddMissingInfo";
+            this.ckbAddMissingInfo.Size = new System.Drawing.Size(143, 17);
+            this.ckbAddMissingInfo.TabIndex = 4;
+            this.ckbAddMissingInfo.Text = "Add missing info to Mods";
+            this.ckbAddMissingInfo.UseVisualStyleBackColor = true;
+            // 
+            // ckbCheckForUpdates
+            // 
+            this.ckbCheckForUpdates.AutoSize = true;
+            this.ckbCheckForUpdates.Location = new System.Drawing.Point(16, 19);
+            this.ckbCheckForUpdates.Name = "ckbCheckForUpdates";
+            this.ckbCheckForUpdates.Size = new System.Drawing.Size(251, 17);
+            this.ckbCheckForUpdates.TabIndex = 0;
+            this.ckbCheckForUpdates.Text = "Check for updates on startup - interval (in days):";
+            this.ckbCheckForUpdates.UseVisualStyleBackColor = true;
+            // 
+            // cbxProgramUpdateCheckInterval
+            // 
+            this.cbxProgramUpdateCheckInterval.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cbxProgramUpdateCheckInterval.FormattingEnabled = true;
+            this.cbxProgramUpdateCheckInterval.Location = new System.Drawing.Point(267, 17);
+            this.cbxProgramUpdateCheckInterval.Name = "cbxProgramUpdateCheckInterval";
+            this.cbxProgramUpdateCheckInterval.Size = new System.Drawing.Size(64, 21);
+            this.cbxProgramUpdateCheckInterval.TabIndex = 1;
+            // 
+            // ckbShowSidePanel
+            // 
+            this.ckbShowSidePanel.AutoSize = true;
+            this.ckbShowSidePanel.Location = new System.Drawing.Point(16, 134);
+            this.ckbShowSidePanel.Name = "ckbShowSidePanel";
+            this.ckbShowSidePanel.Size = new System.Drawing.Size(153, 17);
+            this.ckbShowSidePanel.TabIndex = 8;
+            this.ckbShowSidePanel.Text = "Enable mod info side panel";
+            this.ckbShowSidePanel.UseVisualStyleBackColor = true;
+            // 
+            // ckbSkipReadmeFiles
+            // 
+            this.ckbSkipReadmeFiles.AutoSize = true;
+            this.ckbSkipReadmeFiles.Location = new System.Drawing.Point(16, 42);
+            this.ckbSkipReadmeFiles.Name = "ckbSkipReadmeFiles";
+            this.ckbSkipReadmeFiles.Size = new System.Drawing.Size(151, 17);
+            this.ckbSkipReadmeFiles.TabIndex = 8;
+            this.ckbSkipReadmeFiles.Text = "Don\'t extract ReadMe files";
+            this.ckbSkipReadmeFiles.UseVisualStyleBackColor = true;
+            // 
+            // ckbHideModUpdateWarningIcon
+            // 
+            this.ckbHideModUpdateWarningIcon.AutoSize = true;
+            this.ckbHideModUpdateWarningIcon.Location = new System.Drawing.Point(16, 157);
+            this.ckbHideModUpdateWarningIcon.Name = "ckbHideModUpdateWarningIcon";
+            this.ckbHideModUpdateWarningIcon.Size = new System.Drawing.Size(180, 17);
+            this.ckbHideModUpdateWarningIcon.TabIndex = 8;
+            this.ckbHideModUpdateWarningIcon.Text = "Hide Mod Update Warning Icon ";
+            this.ckbHideModUpdateWarningIcon.UseVisualStyleBackColor = true;
+            // 
+            // butSelectTraceLogDirectory
+            // 
+            this.butSelectTraceLogDirectory.AutoSize = true;
+            this.butSelectTraceLogDirectory.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.butSelectTraceLogDirectory.Location = new System.Drawing.Point(320, 220);
+            this.butSelectTraceLogDirectory.Name = "butSelectTraceLogDirectory";
+            this.butSelectTraceLogDirectory.Size = new System.Drawing.Size(26, 23);
+            this.butSelectTraceLogDirectory.TabIndex = 2;
+            this.butSelectTraceLogDirectory.Text = "...";
+            this.butSelectTraceLogDirectory.UseVisualStyleBackColor = true;
+            this.butSelectTraceLogDirectory.Click += new System.EventHandler(this.butSelectTraceLogDirectory_Click);
+            // 
+            // tbxTraceLogDirectory
+            // 
+            this.tbxTraceLogDirectory.Location = new System.Drawing.Point(16, 220);
+            this.tbxTraceLogDirectory.Name = "tbxTraceLogDirectory";
+            this.tbxTraceLogDirectory.Size = new System.Drawing.Size(290, 20);
+            this.tbxTraceLogDirectory.TabIndex = 1;
+            // 
+            // lblTraceLogDirectory
+            // 
+            this.lblTraceLogDirectory.AutoSize = true;
+            this.lblTraceLogDirectory.Location = new System.Drawing.Point(16, 205);
+            this.lblTraceLogDirectory.Name = "lblTraceLogDirectory";
+            this.lblTraceLogDirectory.Size = new System.Drawing.Size(101, 13);
+            this.lblTraceLogDirectory.TabIndex = 3;
+            this.lblTraceLogDirectory.Text = "TraceLog Directory:";
+            // 
+            // butSelectTempPathDirectory
+            // 
+            this.butSelectTempPathDirectory.AutoSize = true;
+            this.butSelectTempPathDirectory.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.butSelectTempPathDirectory.Location = new System.Drawing.Point(320, 275);
+            this.butSelectTempPathDirectory.Name = "butSelectTempPathDirectory";
+            this.butSelectTempPathDirectory.Size = new System.Drawing.Size(26, 23);
+            this.butSelectTempPathDirectory.TabIndex = 2;
+            this.butSelectTempPathDirectory.Text = "...";
+            this.butSelectTempPathDirectory.UseVisualStyleBackColor = true;
+            this.butSelectTempPathDirectory.Click += new System.EventHandler(this.butSelectTempPathDirectory_Click);
+            // 
+            // tbxTempPathDirectory
+            // 
+            this.tbxTempPathDirectory.Enabled = false;
+            this.tbxTempPathDirectory.Location = new System.Drawing.Point(16, 275);
+            this.tbxTempPathDirectory.Name = "tbxTempPathDirectory";
+            this.tbxTempPathDirectory.Size = new System.Drawing.Size(290, 20);
+            this.tbxTempPathDirectory.TabIndex = 1;
+            this.tbxTempPathDirectory.LostFocus += new System.EventHandler(this.tbxTempPathDirectory_LostFocus);
+            // 
+            // lblTempPathDirectory
+            // 
+            this.lblTempPathDirectory.AutoSize = true;
+            this.lblTempPathDirectory.Location = new System.Drawing.Point(16, 245);
+            this.lblTempPathDirectory.Name = "lblTempPathDirectory";
+            this.lblTempPathDirectory.Size = new System.Drawing.Size(283, 13);
+            this.lblTempPathDirectory.TabIndex = 3;
+            this.lblTempPathDirectory.Text = "Temporary Path Directory: (Folder must be named \"Temp\")";
+            // 
+            // lblTempPathWarning
+            // 
+            this.lblTempPathWarning.AutoSize = true;
+            this.lblTempPathWarning.Location = new System.Drawing.Point(16, 260);
+            this.lblTempPathWarning.Name = "lblTempPathWarning";
+            this.lblTempPathWarning.Size = new System.Drawing.Size(164, 13);
+            this.lblTempPathWarning.TabIndex = 4;
+            this.lblTempPathWarning.Text = "* Requires a restart to be applied!";
+            // 
+            // GeneralSettingsPage
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.flpGeneral);
+            this.Name = "GeneralSettingsPage";
+            this.Size = new System.Drawing.Size(398, 294);
+            this.flpGeneral.ResumeLayout(false);
+            this.groupBox5.ResumeLayout(false);
+            this.groupBox5.PerformLayout();
+            this.ResumeLayout(false);
 
 		}
 
 		#endregion
 
 		private System.Windows.Forms.FlowLayoutPanel flpGeneral;
-		private System.Windows.Forms.GroupBox gbxAssociations;
-		private System.Windows.Forms.FlowLayoutPanel flpFileAssociations;
-		private System.Windows.Forms.CheckBox ckbShellExtensions;
 		private System.Windows.Forms.GroupBox groupBox5;
 		private System.Windows.Forms.CheckBox ckbAddMissingInfo;
 		private System.Windows.Forms.ToolTip ttpTip;
@@ -340,7 +276,6 @@
 		private System.Windows.Forms.Button butSelectTempPathDirectory;
 		private System.Windows.Forms.FolderBrowserDialog fbdTraceLogDirectory;
 		private System.Windows.Forms.FolderBrowserDialog fbdTempPathDirectory;
-		private System.Windows.Forms.CheckBox ckbAssociateURL;
 		private System.Windows.Forms.CheckBox ckbCheckForUpdates;
 		private System.Windows.Forms.CheckBox ckbScanSubfolders;
 		private System.Windows.Forms.CheckBox ckbOverrideLocalNames;

--- a/NexusClient/Settings/UI/GeneralSettingsPage.cs
+++ b/NexusClient/Settings/UI/GeneralSettingsPage.cs
@@ -43,23 +43,7 @@
 				.ToList();
 			cbxProgramUpdateCheckInterval.DisplayMember = "Key";
 			cbxProgramUpdateCheckInterval.ValueMember = "Value";
-
-			foreach (var fasFileAssociation in settings.FileAssociations)
-			{
-			    var ckbFileAssociation = new CheckBox
-			    {
-			        Tag = fasFileAssociation,
-			        Text = $"Associate with {fasFileAssociation.Description} (*{fasFileAssociation.Extension}) files",
-			        AutoSize = true
-			    };
-
-			    BindingHelper.CreateFullBinding(ckbFileAssociation, () => ckbFileAssociation.Checked, fasFileAssociation, () => fasFileAssociation.IsAssociated);
-				flpFileAssociations.Controls.Add(ckbFileAssociation);
-			}
-
-			BindingHelper.CreateFullBinding(ckbShellExtensions, () => ckbShellExtensions.Checked, settings, () => settings.AddShellExtensions);
-			BindingHelper.CreateFullBinding(ckbAssociateURL, () => ckbAssociateURL.Checked, settings, () => settings.AssociateNxmUrl);
-
+            
 			BindingHelper.CreateFullBinding(ckbCheckForUpdates, () => ckbCheckForUpdates.Checked, settings, () => settings.CheckForUpdatesOnStartup);
 			BindingHelper.CreateFullBinding(ckbAddMissingInfo, () => ckbAddMissingInfo.Checked, settings, () => settings.AddMissingModInfo);
 			BindingHelper.CreateFullBinding(ckbScanSubfolders, () => ckbScanSubfolders.Checked, settings, () => settings.ScanSubfoldersForMods);
@@ -73,26 +57,7 @@
 
 			BindingHelper.CreateFullBinding(tbxTraceLogDirectory, () => tbxTraceLogDirectory.Text, settings, () => settings.TraceLogPath);
 			BindingHelper.CreateFullBinding(tbxTempPathDirectory, () => tbxTempPathDirectory.Text, settings, () => settings.TempPath);
-
-			try
-			{
-				if (!settings.CanAssociateFiles)
-				{
-					gbxAssociations.Enabled = false;
-					ttpTip.SetToolTip(gbxAssociations, $"Run {settings.EnvironmentInfo.Settings.ModManagerName} as Administrator to change these settings.");
-				}
-			}
-			catch(MissingMethodException)
-			{
-				var strErrorMessage = string.Format("Looks like you have a broken or incomplete .Net Framework!" + Environment.NewLine + 
-					"You need to install .NetFramework 4.5.2 or 4.6 . " + Environment.NewLine + 
-					"You could alse be required to download the latest Windows updates" +Environment.NewLine + Environment.NewLine +
-					"{0} will be unable to run until you do that and will now close.", SettingsGroup.EnvironmentInfo.Settings.ModManagerName);
-				MessageBox.Show(strErrorMessage, "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-
-			    Environment.Exit(0);
-			}
-
+            
 			ckbCloseManagerAfterGameLaunch.Text = string.Format(ckbCloseManagerAfterGameLaunch.Text, settings.EnvironmentInfo.Settings.ModManagerName);
 		}
 
@@ -105,45 +70,6 @@
 		/// </summary>
 		/// <value>The <see cref="SettingsGroup"/> whose settings will be editable with this view.</value>
 		public SettingsGroup SettingsGroup { get; }
-
-		#endregion
-
-		#region Tool Tip
-
-		/// <summary>
-		/// Handles the <see cref="Control.MouseHover"/> event of the general settings flow panel.
-		/// </summary>
-		/// <remarks>
-		/// This displays the tool tip for the file associations group box when it is disabled.
-		/// </remarks>
-		/// <param name="sender">The object that raised the event.</param>
-		/// <param name="e">An <see cref="EventArgs"/> describing the event arguments.</param>
-		private void flpGeneral_MouseHover(object sender, EventArgs e)
-		{
-			if (!gbxAssociations.Enabled && gbxAssociations.ClientRectangle.Contains(gbxAssociations.PointToClient(Cursor.Position)))
-			{
-				_toolTipShown = true;
-				var pntToolTipLocation = gbxAssociations.PointToClient(Cursor.Position);
-				ttpTip.Show(ttpTip.GetToolTip(gbxAssociations), gbxAssociations, pntToolTipLocation.X, pntToolTipLocation.Y + Cursor.Current.Size.Height);
-			}
-		}
-
-		/// <summary>
-		/// Handles the <see cref="Control.MouseMove"/> event of the general settings flow panel.
-		/// </summary>
-		/// <remarks>
-		/// This hides the tool tip for the file associations group box when appropriate.
-		/// </remarks>
-		/// <param name="sender">The object that raised the event.</param>
-		/// <param name="e">An <see cref="MouseEventArgs"/> describing the event arguments.</param>
-		private void flpGeneral_MouseMove(object sender, MouseEventArgs e)
-		{
-			if (_toolTipShown && !gbxAssociations.ClientRectangle.Contains(gbxAssociations.PointToClient(Cursor.Position)))
-			{
-				_toolTipShown = false;
-				ttpTip.Hide(gbxAssociations);
-			}
-		}
 
 		#endregion
 

--- a/NexusClient/Settings/UI/GeneralSettingsPage.resx
+++ b/NexusClient/Settings/UI/GeneralSettingsPage.resx
@@ -60,7 +60,7 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="https://www.w3.org/XML/1998/namespace" />
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
@@ -112,12 +112,18 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="ttpTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="ttpTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>361, 17</value>
+  </metadata>
+  <metadata name="fbdTraceLogDirectory.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
+  </metadata>
+  <metadata name="fbdTempPathDirectory.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>186, 17</value>
   </metadata>
 </root>

--- a/NexusClient/Settings/UI/OsSettingsPage.Designer.cs
+++ b/NexusClient/Settings/UI/OsSettingsPage.Designer.cs
@@ -32,13 +32,12 @@
             this.flpGeneral = new System.Windows.Forms.FlowLayoutPanel();
             this.gbxAssociations = new System.Windows.Forms.GroupBox();
             this.flpFileAssociations = new System.Windows.Forms.FlowLayoutPanel();
-            this.ckbShellExtensions = new System.Windows.Forms.CheckBox();
             this.ckbAssociateURL = new System.Windows.Forms.CheckBox();
-            this.ttpTip = new System.Windows.Forms.ToolTip(this.components);
             this.groupBoxShellExtensions = new System.Windows.Forms.GroupBox();
-            this.checkBoxShellZip = new System.Windows.Forms.CheckBox();
-            this.checkBoxShellRar = new System.Windows.Forms.CheckBox();
             this.checkBoxShell7z = new System.Windows.Forms.CheckBox();
+            this.checkBoxShellRar = new System.Windows.Forms.CheckBox();
+            this.checkBoxShellZip = new System.Windows.Forms.CheckBox();
+            this.ttpTip = new System.Windows.Forms.ToolTip(this.components);
             this.flpGeneral.SuspendLayout();
             this.gbxAssociations.SuspendLayout();
             this.flpFileAssociations.SuspendLayout();
@@ -68,39 +67,28 @@
             this.gbxAssociations.Location = new System.Drawing.Point(3, 3);
             this.gbxAssociations.MinimumSize = new System.Drawing.Size(368, 0);
             this.gbxAssociations.Name = "gbxAssociations";
-            this.gbxAssociations.Size = new System.Drawing.Size(368, 71);
+            this.gbxAssociations.Size = new System.Drawing.Size(368, 48);
             this.gbxAssociations.TabIndex = 22;
             this.gbxAssociations.TabStop = false;
-            this.gbxAssociations.Text = "File associations";
+            this.gbxAssociations.Text = "General";
             // 
             // flpFileAssociations
             // 
             this.flpFileAssociations.AutoSize = true;
             this.flpFileAssociations.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.flpFileAssociations.Controls.Add(this.ckbShellExtensions);
             this.flpFileAssociations.Controls.Add(this.ckbAssociateURL);
             this.flpFileAssociations.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flpFileAssociations.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
             this.flpFileAssociations.Location = new System.Drawing.Point(3, 16);
             this.flpFileAssociations.Name = "flpFileAssociations";
             this.flpFileAssociations.Padding = new System.Windows.Forms.Padding(10, 3, 3, 3);
-            this.flpFileAssociations.Size = new System.Drawing.Size(362, 52);
+            this.flpFileAssociations.Size = new System.Drawing.Size(362, 29);
             this.flpFileAssociations.TabIndex = 4;
-            // 
-            // ckbShellExtensions
-            // 
-            this.ckbShellExtensions.AutoSize = true;
-            this.ckbShellExtensions.Location = new System.Drawing.Point(13, 6);
-            this.ckbShellExtensions.Name = "ckbShellExtensions";
-            this.ckbShellExtensions.Size = new System.Drawing.Size(231, 17);
-            this.ckbShellExtensions.TabIndex = 3;
-            this.ckbShellExtensions.Text = "Add shell extensions for supported file types";
-            this.ckbShellExtensions.UseVisualStyleBackColor = true;
             // 
             // ckbAssociateURL
             // 
             this.ckbAssociateURL.AutoSize = true;
-            this.ckbAssociateURL.Location = new System.Drawing.Point(13, 29);
+            this.ckbAssociateURL.Location = new System.Drawing.Point(13, 6);
             this.ckbAssociateURL.Name = "ckbAssociateURL";
             this.ckbAssociateURL.Size = new System.Drawing.Size(151, 17);
             this.ckbAssociateURL.TabIndex = 6;
@@ -113,32 +101,12 @@
             this.groupBoxShellExtensions.Controls.Add(this.checkBoxShell7z);
             this.groupBoxShellExtensions.Controls.Add(this.checkBoxShellRar);
             this.groupBoxShellExtensions.Controls.Add(this.checkBoxShellZip);
-            this.groupBoxShellExtensions.Location = new System.Drawing.Point(3, 80);
+            this.groupBoxShellExtensions.Location = new System.Drawing.Point(3, 57);
             this.groupBoxShellExtensions.Name = "groupBoxShellExtensions";
             this.groupBoxShellExtensions.Size = new System.Drawing.Size(365, 100);
             this.groupBoxShellExtensions.TabIndex = 23;
             this.groupBoxShellExtensions.TabStop = false;
             this.groupBoxShellExtensions.Text = "Shell extensions";
-            // 
-            // checkBoxShellZip
-            // 
-            this.checkBoxShellZip.AutoSize = true;
-            this.checkBoxShellZip.Location = new System.Drawing.Point(16, 20);
-            this.checkBoxShellZip.Name = "checkBoxShellZip";
-            this.checkBoxShellZip.Size = new System.Drawing.Size(201, 17);
-            this.checkBoxShellZip.TabIndex = 0;
-            this.checkBoxShellZip.Text = "Add NMM shell extension for .zip files";
-            this.checkBoxShellZip.UseVisualStyleBackColor = true;
-            // 
-            // checkBoxShellRar
-            // 
-            this.checkBoxShellRar.AutoSize = true;
-            this.checkBoxShellRar.Location = new System.Drawing.Point(16, 43);
-            this.checkBoxShellRar.Name = "checkBoxShellRar";
-            this.checkBoxShellRar.Size = new System.Drawing.Size(200, 17);
-            this.checkBoxShellRar.TabIndex = 1;
-            this.checkBoxShellRar.Text = "Add NMM shell extension for .rar files";
-            this.checkBoxShellRar.UseVisualStyleBackColor = true;
             // 
             // checkBoxShell7z
             // 
@@ -150,12 +118,32 @@
             this.checkBoxShell7z.Text = "Add NMM shell extension for .7z files";
             this.checkBoxShell7z.UseVisualStyleBackColor = true;
             // 
-            // AssociationSettingsPage
+            // checkBoxShellRar
+            // 
+            this.checkBoxShellRar.AutoSize = true;
+            this.checkBoxShellRar.Location = new System.Drawing.Point(16, 43);
+            this.checkBoxShellRar.Name = "checkBoxShellRar";
+            this.checkBoxShellRar.Size = new System.Drawing.Size(200, 17);
+            this.checkBoxShellRar.TabIndex = 1;
+            this.checkBoxShellRar.Text = "Add NMM shell extension for .rar files";
+            this.checkBoxShellRar.UseVisualStyleBackColor = true;
+            // 
+            // checkBoxShellZip
+            // 
+            this.checkBoxShellZip.AutoSize = true;
+            this.checkBoxShellZip.Location = new System.Drawing.Point(16, 20);
+            this.checkBoxShellZip.Name = "checkBoxShellZip";
+            this.checkBoxShellZip.Size = new System.Drawing.Size(201, 17);
+            this.checkBoxShellZip.TabIndex = 0;
+            this.checkBoxShellZip.Text = "Add NMM shell extension for .zip files";
+            this.checkBoxShellZip.UseVisualStyleBackColor = true;
+            // 
+            // OsSettingsPage
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.flpGeneral);
-            this.Name = "AssociationSettingsPage";
+            this.Name = "OsSettingsPage";
             this.Size = new System.Drawing.Size(398, 294);
             this.flpGeneral.ResumeLayout(false);
             this.flpGeneral.PerformLayout();
@@ -174,7 +162,6 @@
         private System.Windows.Forms.FlowLayoutPanel flpGeneral;
         private System.Windows.Forms.GroupBox gbxAssociations;
         private System.Windows.Forms.FlowLayoutPanel flpFileAssociations;
-        private System.Windows.Forms.CheckBox ckbShellExtensions;
         private System.Windows.Forms.ToolTip ttpTip;
         private System.Windows.Forms.CheckBox ckbAssociateURL;
         private System.Windows.Forms.GroupBox groupBoxShellExtensions;

--- a/NexusClient/Settings/UI/OsSettingsPage.Designer.cs
+++ b/NexusClient/Settings/UI/OsSettingsPage.Designer.cs
@@ -1,0 +1,185 @@
+﻿namespace Nexus.Client.Settings.UI
+{
+    partial class OsSettingsPage
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.flpGeneral = new System.Windows.Forms.FlowLayoutPanel();
+            this.gbxAssociations = new System.Windows.Forms.GroupBox();
+            this.flpFileAssociations = new System.Windows.Forms.FlowLayoutPanel();
+            this.ckbShellExtensions = new System.Windows.Forms.CheckBox();
+            this.ckbAssociateURL = new System.Windows.Forms.CheckBox();
+            this.ttpTip = new System.Windows.Forms.ToolTip(this.components);
+            this.groupBoxShellExtensions = new System.Windows.Forms.GroupBox();
+            this.checkBoxShellZip = new System.Windows.Forms.CheckBox();
+            this.checkBoxShellRar = new System.Windows.Forms.CheckBox();
+            this.checkBoxShell7z = new System.Windows.Forms.CheckBox();
+            this.flpGeneral.SuspendLayout();
+            this.gbxAssociations.SuspendLayout();
+            this.flpFileAssociations.SuspendLayout();
+            this.groupBoxShellExtensions.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // flpGeneral
+            // 
+            this.flpGeneral.AutoScroll = true;
+            this.flpGeneral.Controls.Add(this.gbxAssociations);
+            this.flpGeneral.Controls.Add(this.groupBoxShellExtensions);
+            this.flpGeneral.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flpGeneral.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            this.flpGeneral.Location = new System.Drawing.Point(0, 0);
+            this.flpGeneral.Name = "flpGeneral";
+            this.flpGeneral.Size = new System.Drawing.Size(398, 294);
+            this.flpGeneral.TabIndex = 25;
+            this.flpGeneral.WrapContents = false;
+            this.flpGeneral.MouseHover += new System.EventHandler(this.flpGeneral_MouseHover);
+            this.flpGeneral.MouseMove += new System.Windows.Forms.MouseEventHandler(this.flpGeneral_MouseMove);
+            // 
+            // gbxAssociations
+            // 
+            this.gbxAssociations.AutoSize = true;
+            this.gbxAssociations.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.gbxAssociations.Controls.Add(this.flpFileAssociations);
+            this.gbxAssociations.Location = new System.Drawing.Point(3, 3);
+            this.gbxAssociations.MinimumSize = new System.Drawing.Size(368, 0);
+            this.gbxAssociations.Name = "gbxAssociations";
+            this.gbxAssociations.Size = new System.Drawing.Size(368, 71);
+            this.gbxAssociations.TabIndex = 22;
+            this.gbxAssociations.TabStop = false;
+            this.gbxAssociations.Text = "File associations";
+            // 
+            // flpFileAssociations
+            // 
+            this.flpFileAssociations.AutoSize = true;
+            this.flpFileAssociations.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.flpFileAssociations.Controls.Add(this.ckbShellExtensions);
+            this.flpFileAssociations.Controls.Add(this.ckbAssociateURL);
+            this.flpFileAssociations.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flpFileAssociations.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            this.flpFileAssociations.Location = new System.Drawing.Point(3, 16);
+            this.flpFileAssociations.Name = "flpFileAssociations";
+            this.flpFileAssociations.Padding = new System.Windows.Forms.Padding(10, 3, 3, 3);
+            this.flpFileAssociations.Size = new System.Drawing.Size(362, 52);
+            this.flpFileAssociations.TabIndex = 4;
+            // 
+            // ckbShellExtensions
+            // 
+            this.ckbShellExtensions.AutoSize = true;
+            this.ckbShellExtensions.Location = new System.Drawing.Point(13, 6);
+            this.ckbShellExtensions.Name = "ckbShellExtensions";
+            this.ckbShellExtensions.Size = new System.Drawing.Size(231, 17);
+            this.ckbShellExtensions.TabIndex = 3;
+            this.ckbShellExtensions.Text = "Add shell extensions for supported file types";
+            this.ckbShellExtensions.UseVisualStyleBackColor = true;
+            // 
+            // ckbAssociateURL
+            // 
+            this.ckbAssociateURL.AutoSize = true;
+            this.ckbAssociateURL.Location = new System.Drawing.Point(13, 29);
+            this.ckbAssociateURL.Name = "ckbAssociateURL";
+            this.ckbAssociateURL.Size = new System.Drawing.Size(151, 17);
+            this.ckbAssociateURL.TabIndex = 6;
+            this.ckbAssociateURL.Text = "Associate with NXM URLs";
+            this.ckbAssociateURL.UseVisualStyleBackColor = true;
+            // 
+            // groupBoxShellExtensions
+            // 
+            this.groupBoxShellExtensions.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.groupBoxShellExtensions.Controls.Add(this.checkBoxShell7z);
+            this.groupBoxShellExtensions.Controls.Add(this.checkBoxShellRar);
+            this.groupBoxShellExtensions.Controls.Add(this.checkBoxShellZip);
+            this.groupBoxShellExtensions.Location = new System.Drawing.Point(3, 80);
+            this.groupBoxShellExtensions.Name = "groupBoxShellExtensions";
+            this.groupBoxShellExtensions.Size = new System.Drawing.Size(365, 100);
+            this.groupBoxShellExtensions.TabIndex = 23;
+            this.groupBoxShellExtensions.TabStop = false;
+            this.groupBoxShellExtensions.Text = "Shell extensions";
+            // 
+            // checkBoxShellZip
+            // 
+            this.checkBoxShellZip.AutoSize = true;
+            this.checkBoxShellZip.Location = new System.Drawing.Point(16, 20);
+            this.checkBoxShellZip.Name = "checkBoxShellZip";
+            this.checkBoxShellZip.Size = new System.Drawing.Size(201, 17);
+            this.checkBoxShellZip.TabIndex = 0;
+            this.checkBoxShellZip.Text = "Add NMM shell extension for .zip files";
+            this.checkBoxShellZip.UseVisualStyleBackColor = true;
+            // 
+            // checkBoxShellRar
+            // 
+            this.checkBoxShellRar.AutoSize = true;
+            this.checkBoxShellRar.Location = new System.Drawing.Point(16, 43);
+            this.checkBoxShellRar.Name = "checkBoxShellRar";
+            this.checkBoxShellRar.Size = new System.Drawing.Size(200, 17);
+            this.checkBoxShellRar.TabIndex = 1;
+            this.checkBoxShellRar.Text = "Add NMM shell extension for .rar files";
+            this.checkBoxShellRar.UseVisualStyleBackColor = true;
+            // 
+            // checkBoxShell7z
+            // 
+            this.checkBoxShell7z.AutoSize = true;
+            this.checkBoxShell7z.Location = new System.Drawing.Point(16, 66);
+            this.checkBoxShell7z.Name = "checkBoxShell7z";
+            this.checkBoxShell7z.Size = new System.Drawing.Size(199, 17);
+            this.checkBoxShell7z.TabIndex = 2;
+            this.checkBoxShell7z.Text = "Add NMM shell extension for .7z files";
+            this.checkBoxShell7z.UseVisualStyleBackColor = true;
+            // 
+            // AssociationSettingsPage
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.flpGeneral);
+            this.Name = "AssociationSettingsPage";
+            this.Size = new System.Drawing.Size(398, 294);
+            this.flpGeneral.ResumeLayout(false);
+            this.flpGeneral.PerformLayout();
+            this.gbxAssociations.ResumeLayout(false);
+            this.gbxAssociations.PerformLayout();
+            this.flpFileAssociations.ResumeLayout(false);
+            this.flpFileAssociations.PerformLayout();
+            this.groupBoxShellExtensions.ResumeLayout(false);
+            this.groupBoxShellExtensions.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.FlowLayoutPanel flpGeneral;
+        private System.Windows.Forms.GroupBox gbxAssociations;
+        private System.Windows.Forms.FlowLayoutPanel flpFileAssociations;
+        private System.Windows.Forms.CheckBox ckbShellExtensions;
+        private System.Windows.Forms.ToolTip ttpTip;
+        private System.Windows.Forms.CheckBox ckbAssociateURL;
+        private System.Windows.Forms.GroupBox groupBoxShellExtensions;
+        private System.Windows.Forms.CheckBox checkBoxShell7z;
+        private System.Windows.Forms.CheckBox checkBoxShellRar;
+        private System.Windows.Forms.CheckBox checkBoxShellZip;
+    }
+}

--- a/NexusClient/Settings/UI/OsSettingsPage.Designer.cs
+++ b/NexusClient/Settings/UI/OsSettingsPage.Designer.cs
@@ -38,10 +38,12 @@
             this.checkBoxShellRar = new System.Windows.Forms.CheckBox();
             this.checkBoxShellZip = new System.Windows.Forms.CheckBox();
             this.ttpTip = new System.Windows.Forms.ToolTip(this.components);
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.flpGeneral.SuspendLayout();
             this.gbxAssociations.SuspendLayout();
             this.flpFileAssociations.SuspendLayout();
             this.groupBoxShellExtensions.SuspendLayout();
+            this.flowLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // flpGeneral
@@ -70,7 +72,7 @@
             this.gbxAssociations.Size = new System.Drawing.Size(368, 48);
             this.gbxAssociations.TabIndex = 22;
             this.gbxAssociations.TabStop = false;
-            this.gbxAssociations.Text = "General";
+            this.gbxAssociations.Text = "Associations";
             // 
             // flpFileAssociations
             // 
@@ -97,13 +99,13 @@
             // 
             // groupBoxShellExtensions
             // 
+            this.groupBoxShellExtensions.AutoSize = true;
             this.groupBoxShellExtensions.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.groupBoxShellExtensions.Controls.Add(this.checkBoxShell7z);
-            this.groupBoxShellExtensions.Controls.Add(this.checkBoxShellRar);
-            this.groupBoxShellExtensions.Controls.Add(this.checkBoxShellZip);
+            this.groupBoxShellExtensions.Controls.Add(this.flowLayoutPanel1);
             this.groupBoxShellExtensions.Location = new System.Drawing.Point(3, 57);
+            this.groupBoxShellExtensions.MinimumSize = new System.Drawing.Size(368, 0);
             this.groupBoxShellExtensions.Name = "groupBoxShellExtensions";
-            this.groupBoxShellExtensions.Size = new System.Drawing.Size(365, 100);
+            this.groupBoxShellExtensions.Size = new System.Drawing.Size(368, 94);
             this.groupBoxShellExtensions.TabIndex = 23;
             this.groupBoxShellExtensions.TabStop = false;
             this.groupBoxShellExtensions.Text = "Shell extensions";
@@ -111,32 +113,47 @@
             // checkBoxShell7z
             // 
             this.checkBoxShell7z.AutoSize = true;
-            this.checkBoxShell7z.Location = new System.Drawing.Point(16, 66);
+            this.checkBoxShell7z.Location = new System.Drawing.Point(13, 52);
             this.checkBoxShell7z.Name = "checkBoxShell7z";
-            this.checkBoxShell7z.Size = new System.Drawing.Size(199, 17);
+            this.checkBoxShell7z.Size = new System.Drawing.Size(170, 17);
             this.checkBoxShell7z.TabIndex = 2;
-            this.checkBoxShell7z.Text = "Add NMM shell extension for .7z files";
+            this.checkBoxShell7z.Text = "Add shell extension for .7z files";
             this.checkBoxShell7z.UseVisualStyleBackColor = true;
             // 
             // checkBoxShellRar
             // 
             this.checkBoxShellRar.AutoSize = true;
-            this.checkBoxShellRar.Location = new System.Drawing.Point(16, 43);
+            this.checkBoxShellRar.Location = new System.Drawing.Point(13, 29);
             this.checkBoxShellRar.Name = "checkBoxShellRar";
-            this.checkBoxShellRar.Size = new System.Drawing.Size(200, 17);
+            this.checkBoxShellRar.Size = new System.Drawing.Size(171, 17);
             this.checkBoxShellRar.TabIndex = 1;
-            this.checkBoxShellRar.Text = "Add NMM shell extension for .rar files";
+            this.checkBoxShellRar.Text = "Add shell extension for .rar files";
             this.checkBoxShellRar.UseVisualStyleBackColor = true;
             // 
             // checkBoxShellZip
             // 
             this.checkBoxShellZip.AutoSize = true;
-            this.checkBoxShellZip.Location = new System.Drawing.Point(16, 20);
+            this.checkBoxShellZip.Location = new System.Drawing.Point(13, 6);
             this.checkBoxShellZip.Name = "checkBoxShellZip";
-            this.checkBoxShellZip.Size = new System.Drawing.Size(201, 17);
+            this.checkBoxShellZip.Size = new System.Drawing.Size(172, 17);
             this.checkBoxShellZip.TabIndex = 0;
-            this.checkBoxShellZip.Text = "Add NMM shell extension for .zip files";
+            this.checkBoxShellZip.Text = "Add shell extension for .zip files";
             this.checkBoxShellZip.UseVisualStyleBackColor = true;
+            // 
+            // flowLayoutPanel1
+            // 
+            this.flowLayoutPanel1.AutoSize = true;
+            this.flowLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.flowLayoutPanel1.Controls.Add(this.checkBoxShellZip);
+            this.flowLayoutPanel1.Controls.Add(this.checkBoxShellRar);
+            this.flowLayoutPanel1.Controls.Add(this.checkBoxShell7z);
+            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 16);
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            this.flowLayoutPanel1.Padding = new System.Windows.Forms.Padding(10, 3, 3, 3);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(362, 75);
+            this.flowLayoutPanel1.TabIndex = 3;
             // 
             // OsSettingsPage
             // 
@@ -153,6 +170,8 @@
             this.flpFileAssociations.PerformLayout();
             this.groupBoxShellExtensions.ResumeLayout(false);
             this.groupBoxShellExtensions.PerformLayout();
+            this.flowLayoutPanel1.ResumeLayout(false);
+            this.flowLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -168,5 +187,6 @@
         private System.Windows.Forms.CheckBox checkBoxShell7z;
         private System.Windows.Forms.CheckBox checkBoxShellRar;
         private System.Windows.Forms.CheckBox checkBoxShellZip;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
     }
 }

--- a/NexusClient/Settings/UI/OsSettingsPage.cs
+++ b/NexusClient/Settings/UI/OsSettingsPage.cs
@@ -1,0 +1,113 @@
+﻿namespace Nexus.Client.Settings.UI
+{
+    using System;
+    using System.Windows.Forms;
+
+    using Util;
+
+    /// <summary>
+    /// A view allowing the editing of general settings.
+    /// </summary>
+    public partial class OsSettingsPage : UserControl, ISettingsGroupView
+	{
+		private bool _toolTipShown;
+		
+		#region Constructors
+
+		/// <summary>
+		/// A sinmple consturctor that initializes the object with the given values.
+		/// </summary>
+		/// <param name="settings">The settings group whose settings will be editable with this view.</param>
+		public OsSettingsPage(OsSettingsGroup settings)
+		{
+			SettingsGroup = settings;
+			InitializeComponent();
+            
+			foreach (var fasFileAssociation in settings.FileAssociations)
+			{
+			    var ckbFileAssociation = new CheckBox
+			    {
+			        Tag = fasFileAssociation,
+			        Text = $"Associate with {fasFileAssociation.Description} (*{fasFileAssociation.Extension}) files",
+			        AutoSize = true
+			    };
+
+			    BindingHelper.CreateFullBinding(ckbFileAssociation, () => ckbFileAssociation.Checked, fasFileAssociation, () => fasFileAssociation.IsAssociated);
+				flpFileAssociations.Controls.Add(ckbFileAssociation);
+			}
+
+			BindingHelper.CreateFullBinding(ckbShellExtensions, () => ckbShellExtensions.Checked, settings, () => settings.AddShellExtensions);
+			BindingHelper.CreateFullBinding(ckbAssociateURL, () => ckbAssociateURL.Checked, settings, () => settings.AssociateNxmUrl);
+
+			try
+			{
+				if (!settings.CanAssociateFiles)
+				{
+					gbxAssociations.Enabled = false;
+					ttpTip.SetToolTip(gbxAssociations, $"Run {settings.EnvironmentInfo.Settings.ModManagerName} as Administrator to change these settings.");
+				}
+			}
+			catch(MissingMethodException)
+			{
+				var strErrorMessage = string.Format("Looks like you have a broken or incomplete .Net Framework!" + Environment.NewLine + 
+					"You need to install .NetFramework 4.5.2 or 4.6 . " + Environment.NewLine + 
+					"You could alse be required to download the latest Windows updates" +Environment.NewLine + Environment.NewLine +
+					"{0} will be unable to run until you do that and will now close.", SettingsGroup.EnvironmentInfo.Settings.ModManagerName);
+				MessageBox.Show(strErrorMessage, "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+
+			    Environment.Exit(0);
+			}
+		}
+
+		#endregion
+
+		#region ISettingsGroupView Members
+
+		/// <summary>
+		/// Gets the <see cref="SettingsGroup"/> whose settings will be editable with this view.
+		/// </summary>
+		/// <value>The <see cref="SettingsGroup"/> whose settings will be editable with this view.</value>
+		public SettingsGroup SettingsGroup { get; }
+
+		#endregion
+
+		#region Tool Tip
+
+		/// <summary>
+		/// Handles the <see cref="Control.MouseHover"/> event of the general settings flow panel.
+		/// </summary>
+		/// <remarks>
+		/// This displays the tool tip for the file associations group box when it is disabled.
+		/// </remarks>
+		/// <param name="sender">The object that raised the event.</param>
+		/// <param name="e">An <see cref="EventArgs"/> describing the event arguments.</param>
+		private void flpGeneral_MouseHover(object sender, EventArgs e)
+		{
+			if (!gbxAssociations.Enabled && gbxAssociations.ClientRectangle.Contains(gbxAssociations.PointToClient(Cursor.Position)))
+			{
+				_toolTipShown = true;
+				var pntToolTipLocation = gbxAssociations.PointToClient(Cursor.Position);
+				ttpTip.Show(ttpTip.GetToolTip(gbxAssociations), gbxAssociations, pntToolTipLocation.X, pntToolTipLocation.Y + Cursor.Current.Size.Height);
+			}
+		}
+
+		/// <summary>
+		/// Handles the <see cref="Control.MouseMove"/> event of the general settings flow panel.
+		/// </summary>
+		/// <remarks>
+		/// This hides the tool tip for the file associations group box when appropriate.
+		/// </remarks>
+		/// <param name="sender">The object that raised the event.</param>
+		/// <param name="e">An <see cref="MouseEventArgs"/> describing the event arguments.</param>
+		private void flpGeneral_MouseMove(object sender, MouseEventArgs e)
+		{
+			if (_toolTipShown && !gbxAssociations.ClientRectangle.Contains(gbxAssociations.PointToClient(Cursor.Position)))
+			{
+				_toolTipShown = false;
+				ttpTip.Hide(gbxAssociations);
+			}
+		}
+
+		#endregion
+	}
+}

--- a/NexusClient/Settings/UI/OsSettingsPage.cs
+++ b/NexusClient/Settings/UI/OsSettingsPage.cs
@@ -36,16 +36,21 @@
 				flpFileAssociations.Controls.Add(ckbFileAssociation);
 			}
 
-			BindingHelper.CreateFullBinding(ckbShellExtensions, () => ckbShellExtensions.Checked, settings, () => settings.AddShellExtensions);
 			BindingHelper.CreateFullBinding(ckbAssociateURL, () => ckbAssociateURL.Checked, settings, () => settings.AssociateNxmUrl);
 
-			try
+		    BindingHelper.CreateFullBinding(checkBoxShellZip, () => checkBoxShellZip.Checked, settings, () => settings.AddShellExtensionZip);
+		    BindingHelper.CreateFullBinding(checkBoxShellRar, () => checkBoxShellRar.Checked, settings, () => settings.AddShellExtensionRar);
+		    BindingHelper.CreateFullBinding(checkBoxShell7z, () => checkBoxShell7z.Checked, settings, () => settings.AddShellExtension7z);
+
+            try
 			{
 				if (!settings.CanAssociateFiles)
 				{
 					gbxAssociations.Enabled = false;
+				    groupBoxShellExtensions.Enabled = false;
 					ttpTip.SetToolTip(gbxAssociations, $"Run {settings.EnvironmentInfo.Settings.ModManagerName} as Administrator to change these settings.");
-				}
+				    ttpTip.SetToolTip(groupBoxShellExtensions, $"Run {settings.EnvironmentInfo.Settings.ModManagerName} as Administrator to change these settings.");
+                }
 			}
 			catch(MissingMethodException)
 			{
@@ -89,7 +94,14 @@
 				var pntToolTipLocation = gbxAssociations.PointToClient(Cursor.Position);
 				ttpTip.Show(ttpTip.GetToolTip(gbxAssociations), gbxAssociations, pntToolTipLocation.X, pntToolTipLocation.Y + Cursor.Current.Size.Height);
 			}
-		}
+
+		    if (!groupBoxShellExtensions.Enabled && groupBoxShellExtensions.ClientRectangle.Contains(groupBoxShellExtensions.PointToClient(Cursor.Position)))
+		    {
+		        _toolTipShown = true;
+		        var pntToolTipLocation = groupBoxShellExtensions.PointToClient(Cursor.Position);
+		        ttpTip.Show(ttpTip.GetToolTip(groupBoxShellExtensions), groupBoxShellExtensions, pntToolTipLocation.X, pntToolTipLocation.Y + Cursor.Current.Size.Height);
+		    }
+        }
 
 		/// <summary>
 		/// Handles the <see cref="Control.MouseMove"/> event of the general settings flow panel.

--- a/NexusClient/Settings/UI/OsSettingsPage.resx
+++ b/NexusClient/Settings/UI/OsSettingsPage.resx
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="ttpTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>186, 17</value>
+  </metadata>
+</root>


### PR DESCRIPTION
**tl;dr:** I remade the Settings window to allow for better control over shell extensions, file and URL associations. Also checks if other apps overwrite these settings.

Currently the Settings window looks like this:
![image](https://user-images.githubusercontent.com/864820/44229509-957e8d80-a198-11e8-9c79-3ab58fbd3ff9.png)

With my changes it is now split into this:
![image](https://user-images.githubusercontent.com/864820/44229692-12aa0280-a199-11e8-8599-28c0982b46db.png)

I've added persistent settings which allow any number of shell extensions to be added (but the checkboxes are still manually added to the settings page, for now). Also a persistent setting for the NXM association.

The persistent settings allow NMM to check whether or not it expects to have these associations, but for some reason lost them. This seems to be a recurring problem (many reports of "I'm clicking download but NMM does nothing", I assume many have simply lost the NXM association to other programs like Vortex).

This same check is also performed for shell extensions, but I assume this is not going to be a frequent problem.

I'm no UX designer, so any suggestions on layout etc. are welcome, but I tried to keep it as close to the previous look as possible.