### PR TITLE
Fix missing dll's in GameModes folder after build

### DIFF
--- a/Script Types/CSharpScript/CSharpScript.csproj
+++ b/Script Types/CSharpScript/CSharpScript.csproj
@@ -92,6 +92,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\Support\BuildTasks\CopyScriptTypes.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Script Types/ModScript/ModScript.csproj
+++ b/Script Types/ModScript/ModScript.csproj
@@ -149,6 +149,7 @@
     <AntlrToolPath>$(SolutionDir)\lib\Antlr\Antlr3.exe</AntlrToolPath>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\lib\Antlr\Antlr3.targets" />
+  <Import Project="$(SolutionDir)\Support\BuildTasks\CopyScriptTypes.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Script Types/XmlScript/XmlScript.csproj
+++ b/Script Types/XmlScript/XmlScript.csproj
@@ -453,6 +453,7 @@
     <AntlrToolPath>$(SolutionDir)\lib\Antlr\Antlr3.exe</AntlrToolPath>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\lib\Antlr\Antlr3.targets" />
+  <Import Project="$(SolutionDir)\Support\BuildTasks\CopyScriptTypes.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Support/AntlrBuildTask/AntlrBuildTask.csproj
+++ b/Support/AntlrBuildTask/AntlrBuildTask.csproj
@@ -23,12 +23,13 @@
     <SccProvider>
     </SccProvider>
     <TargetFrameworkProfile />
+    <IntermediatePath>..\..\Stage\obj\$(Configuration)</IntermediatePath>
+    <OutputPath>..\..\lib\Antlr\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\lib\Antlr\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -37,7 +38,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\lib\Antlr\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/Support/BuildTasks/BuildTasks.csproj
+++ b/Support/BuildTasks/BuildTasks.csproj
@@ -18,12 +18,13 @@
     </UpgradeBackupLocation>
     <OldToolsVersion>3.5</OldToolsVersion>
     <TargetFrameworkProfile />
+    <IntermediatePath>..\..\Stage\obj\$(Configuration)</IntermediatePath>
+    <OutputPath>..\..\lib\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\lib\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -32,7 +33,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\lib\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/Support/BuildTasks/CopyScriptTypes.targets
+++ b/Support/BuildTasks/CopyScriptTypes.targets
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	
+	<Target Name="CopyScriptTypes" AfterTargets="Build">
+		<ItemGroup>
+		    <ScriptTypes Include="$(SolutionDir)\Stage\$(Configuration)\ScriptTypes\*.dll" />
+		</ItemGroup>
+
+		<Message Text="Copying ScriptType files to GameModes..." Importance="High" />
+		<Copy SourceFiles="@(ScriptTypes)" DestinationFolder="$(SolutionDir)\Stage\$(Configuration)\GameModes\%(RecursiveDir)" SkipUnchangedFiles="true" />
+	</Target>
+</Project>


### PR DESCRIPTION
Added MSBuild target to copy ScriptTypes to GameModes directory after build.

I keep getting logs along the line of 
`NexusClient.exe Error: 0 : Cannot load D:\Git\GitHub\Nexus-Mod-Manager\Stage\Debug\GameModes\Skyrim.CSharpScript.dll: cannot find dependency CSharpScript, Version=0.66.0.0, Culture=neutral, PublicKeyToken=null`