### PR TITLE
Improvements to identifying and tagging manually added mods

### DIFF
--- a/NexusClient/ModManagement/AutoTagger.cs
+++ b/NexusClient/ModManagement/AutoTagger.cs
@@ -69,7 +69,7 @@ namespace Nexus.Client.ModManagement
 					mods.Clear();
 					
 					//get file specific info
-					var mfiFileInfo = ModRepository.GetFileInfoForFile(mod.Filename);
+                    var mfiFileInfo = ModRepository.GetModFileInfoForFile(mod.Filename);
 
                     if (mfiFileInfo == null)
 					{

--- a/NexusClient/ModRepositories/IModRepository.cs
+++ b/NexusClient/ModRepositories/IModRepository.cs
@@ -110,16 +110,23 @@
 		/// <summary>
 		/// Gets the mod info for the mod to which the specified download file belongs.
 		/// </summary>
-		/// <param name="fileName">The name of the file whose mod's info is to be returned..</param>
+		/// <param name="fileName">The name of the file whose mod's info is to be returned.</param>
 		/// <returns>The info for the mod to which the specified file belongs.</returns>
 		IModInfo GetModInfoForFile(string fileName);
 
-		/// <summary>
-		/// Gets the info for the specified mod.
-		/// </summary>
-		/// <param name="modId">The id of the mod info is be retrieved.</param>
-		/// <returns>The info for the specified mod.</returns>
-		IModInfo GetModInfo(string modId);
+        /// <summary>
+        /// Gets the mod file info which the specified download file belongs.
+        /// </summary>
+        /// <param name="fileName">The name of the file whose info is to be returned.</param>
+        /// <returns>The info for the mod specified file.</returns>
+        IModFileInfo GetModFileInfoForFile(string fileName);
+
+        /// <summary>
+        /// Gets the info for the specified mod.
+        /// </summary>
+        /// <param name="modId">The id of the mod info is be retrieved.</param>
+        /// <returns>The info for the specified mod.</returns>
+        IModInfo GetModInfo(string modId);
 
 		/// <summary>
 		/// Gets the info for the specified file list.

--- a/NexusClient/ModRepositories/ModFileInfo.cs
+++ b/NexusClient/ModRepositories/ModFileInfo.cs
@@ -22,10 +22,10 @@
         /// <param name="modFile">ModFile to get information from.</param>
         public ModFileInfo(ModFile modFile)
         {
-            Id = modFile.FileID.ToString();
-            Filename = modFile.FileName;
-            Name = modFile.Name;
-            HumanReadableVersion = modFile.ModVersion;
+            Id = modFile?.FileID.ToString();
+            Filename = modFile?.FileName;
+            Name = modFile?.Name;
+            HumanReadableVersion = modFile?.ModVersion;
         }
     }
 }

--- a/NexusClient/ModRepositories/NexusModsApiRepository.cs
+++ b/NexusClient/ModRepositories/NexusModsApiRepository.cs
@@ -187,8 +187,25 @@
 			}
 		}
 
-		/// <inheritdoc cref="IModRepository"/>
-		public IModInfo GetModInfo(string modId)
+        /// <inheritdoc cref="IModRepository"/>
+        public IModFileInfo GetModFileInfoForFile(string fileName)
+        {
+            try
+            {
+                var hash = Md5.CalculateMd5(fileName);
+
+                // TODO: Probably need to handle cases with multiple hits.
+                return new ModFileInfo(_apiCallManager.Mods.GetModsByFileHash(GameDomainName, hash).Result[0].File);
+            }
+            catch (AggregateException a)
+            {
+                ReactToAggregateException(a);
+                return null;
+            }
+        }
+
+        /// <inheritdoc cref="IModRepository"/>
+        public IModInfo GetModInfo(string modId)
 		{
 			try
 			{
@@ -347,10 +364,11 @@
 
 				var filename = Path.GetFileName(fileName);
 				var files = _apiCallManager.ModFiles.GetModFiles(GameDomainName, Convert.ToInt32(modId), FileCategory.Main, FileCategory.Miscellaneous, FileCategory.Optional, FileCategory.Update, FileCategory.Deleted, FileCategory.Old).Result.Files;
-				var fileInfo = files.Find(x => x.Name.Equals(filename, StringComparison.OrdinalIgnoreCase)) ??
-							   files.Find(x => x.Name.Replace(' ', '_').Equals(filename, StringComparison.OrdinalIgnoreCase));
+                var fileInfo = (files.Find(x => x.Name.Equals(filename, StringComparison.OrdinalIgnoreCase)) ?? 
+                               files.Find(x => x.Name.Replace(' ', '_').Equals(filename, StringComparison.OrdinalIgnoreCase))) ??
+                               files.Find(x => x.Name.Replace(' ', '-').Equals(filename, StringComparison.OrdinalIgnoreCase));
 
-				return new ModFileInfo(fileInfo);
+                return new ModFileInfo(fileInfo);
 			}
 			catch (AggregateException a)
 			{


### PR DESCRIPTION
Tweaked mod filename parsing, and changed API call to use MD5 search to find mod file info in the AutoTagger.

Hopefully resolves the problems described in #745 