### PR TITLE
#895 Fix for category view filter resetting wrong.

### DIFF
--- a/NexusClient/ModManagement/UI/ModManagerControl.cs
+++ b/NexusClient/ModManagement/UI/ModManagerControl.cs
@@ -1739,7 +1739,7 @@
 				}
 			}
 
-			clwCategoryView.ReloadList(false);
+			clwCategoryView.ReloadList(true);
 			UpdateModsCount(this, e);
 			SetCommandExecutableStatus();
 		}


### PR DESCRIPTION
Fix for category view filter resetting incorrectly when list changes and filter is applied.