### PR TITLE
[PluginManagement] Remove leftover early ESL sorting code causing sor…

### DIFF
--- a/Game Modes/GamebryoBase/PluginManagement/GamebryoPluginOrderValidator.cs
+++ b/Game Modes/GamebryoBase/PluginManagement/GamebryoPluginOrderValidator.cs
@@ -130,26 +130,6 @@ namespace Nexus.Client.Games.Gamebryo.PluginManagement
 				}
 			}
 
-			intFirstNonMasterIndex = p_lstPlugins.Count - 1;
-			for (Int32 i = p_lstPlugins.Count - 1; i >= 0; i--)
-			{
-				if (!((GamebryoPlugin)p_lstPlugins[i]).IsMaster)
-				{
-					if (booHasMove)
-						((ThreadSafeObservableList<Plugin>)p_lstPlugins).Move(i, intFirstNonMasterIndex);
-					else
-					{
-						Plugin plgPlugin = p_lstPlugins[i];
-						p_lstPlugins.RemoveAt(i);
-						if (intFirstNonMasterIndex >= p_lstPlugins.Count)
-							p_lstPlugins.Add(plgPlugin);
-						else
-							p_lstPlugins.Insert(intFirstNonMasterIndex, plgPlugin);
-					}
-					intFirstNonMasterIndex--;
-				}
-			}
-
 			// Makes sure no plugin is loaded before his master.
 			for (Int32 i = p_lstPlugins.Count - 1; i >= 0; i--)
 			{


### PR DESCRIPTION
…ting speed issues from #692 and #681.

Removed remnants of code block I originally introduced for ESL sorting

Originally introduced
https://github.com/Nexus-Mods/Nexus-Mod-Manager/commit/5fb8b69d8fa9d5a3013f3dd6c59f552e9294dd23

Later revised and left over
https://github.com/Nexus-Mods/Nexus-Mod-Manager/commit/8a3d8bfa89352a0cfb33464f76bfc68ce54c3e10

Essentially it was causing the "put masters before non-masters" to run twice. Redundant and causing a serious speed slow down.