### PR TITLE
Ensure ApplyAI() doesn't crash NMM if there's file write access issues.

### DIFF
--- a/Game Modes/Enderal/Tools/AI/ArchiveInvalidation.cs
+++ b/Game Modes/Enderal/Tools/AI/ArchiveInvalidation.cs
@@ -1,15 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using Nexus.Client.Games.Gamebryo.Tools.AI;
-using Nexus.Client.Util;
-using Nexus.Client.Games.Tools;
-using Nexus.Client.Commands;
-using Nexus.Client.Games.Gamebryo;
-
-namespace Nexus.Client.Games.Enderal.Tools.AI
+﻿namespace Nexus.Client.Games.Enderal.Tools.AI
 {
-	/// <summary>
+    using System;
+	using System.Diagnostics;
+	using System.IO;
+	using System.Windows.Forms;
+
+	using Nexus.Client.Util;
+    using Nexus.Client.Games.Tools;
+    using Nexus.Client.Commands;
+	
+    /// <summary>
 	/// Controls ArchiveInvalidation.
 	/// </summary>
 	public class ArchiveInvalidation : ITool
@@ -92,16 +92,44 @@ namespace Nexus.Client.Games.Enderal.Tools.AI
         {
             if (ConfirmAiReset())
             {
-                string strPluginsPath = GameMode.PluginDirectory;
-                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("Skyrim - *.bsa"))
-                    fi.LastWriteTime = new DateTime(2019, 2, 1);
-                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("Update.bsa"))
-                    fi.LastWriteTime = new DateTime(2019, 2, 2);
-                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("E - *.bsa"))
-                    fi.LastWriteTime = new DateTime(2019, 2, 3);
-                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("L - *.bsa"))
-                    fi.LastWriteTime = new DateTime(2019, 2, 4);
-            }
+                var pluginsPath = GameMode.PluginDirectory;
+
+                try
+                {
+                    foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("Skyrim - *.bsa"))
+                    {
+                        fi.LastWriteTime = new DateTime(2019, 2, 1);
+                    }
+
+                    foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("Update.bsa"))
+                    {
+                        fi.LastWriteTime = new DateTime(2019, 2, 2);
+                    }
+
+                    foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("E - *.bsa"))
+                    {
+                        fi.LastWriteTime = new DateTime(2019, 2, 3);
+                    }
+
+                    foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("L - *.bsa"))
+                    {
+                        fi.LastWriteTime = new DateTime(2019, 2, 4);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Trace.TraceError("ApplyAI - Could not set LastWriteTime.");
+                    TraceUtil.TraceException(ex);
+
+                    MessageBox.Show(
+                        "Could not apply Archive Invalidation, at least one file could not be modified.\n" +
+                        "Please try again, or check trace log for more info.\n\n" +
+                        ex.Message,
+                        "Archive Invalidation failed",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
+                }
+			}
         }
 	}
 }

--- a/Game Modes/Fallout3/Tools/AI/ArchiveInvalidation.cs
+++ b/Game Modes/Fallout3/Tools/AI/ArchiveInvalidation.cs
@@ -1,13 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using Nexus.Client.Games.Gamebryo.Tools.AI;
-using Nexus.Client.Util;
-using System.Windows.Forms;
-
-namespace Nexus.Client.Games.Fallout3.Tools.AI
+﻿namespace Nexus.Client.Games.Fallout3.Tools.AI
 {
-	/// <summary>
+    using System;
+    using System.Collections.Generic;
+	using System.Diagnostics;
+	using System.IO;
+	using System.Windows.Forms;
+
+	using Nexus.Client.Games.Gamebryo.Tools.AI;
+    using Nexus.Client.Util;
+    
+    /// <summary>
 	/// UI.Controls ArchiveInvalidation.
 	/// </summary>
 	public class ArchiveInvalidation : ArchiveInvalidationBase
@@ -65,34 +67,71 @@ namespace Nexus.Client.Games.Fallout3.Tools.AI
 		/// </summary>
 		protected override void ApplyAI()
 		{
-			string strPluginsPath = GameMode.PluginDirectory;
-			foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("Fallout - *.bsa"))
-				fi.LastWriteTime = new DateTime(2008, 10, 1);
-			foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("Anchorage - *.bsa"))
-				fi.LastWriteTime = new DateTime(2008, 10, 2);
-			foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("ThePitt - *.bsa"))
-				fi.LastWriteTime = new DateTime(2008, 10, 3);
-			foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("BrokenSteel - *.bsa"))
-				fi.LastWriteTime = new DateTime(2008, 10, 4);
-			foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("PointLookout - *.bsa"))
-				fi.LastWriteTime = new DateTime(2008, 10, 5);
-			foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("Zeta - *.bsa"))
-				fi.LastWriteTime = new DateTime(2008, 10, 6);
+			var pluginsPath = GameMode.PluginDirectory;
 
-			string strFalloutIniPath = GameMode.SettingsFiles.IniPath;
-			IniMethods.WritePrivateProfileInt32("Archive", "bInvalidateOlderFiles", 1, strFalloutIniPath);
-			IniMethods.WritePrivateProfileInt32("General", "bLoadFaceGenHeadEGTFiles", 1, strFalloutIniPath);
-			IniMethods.WritePrivateProfileString("Archive", "SInvalidationFile", "", strFalloutIniPath);
-			File.Delete(Path.Combine(strPluginsPath, "archiveinvalidation.txt"));
-			File.WriteAllBytes(Path.Combine(strPluginsPath, AI_BSA), new byte[] {
-                0x42, 0x53, 0x41, 0x00, 0x67, 0x00, 0x00, 0x00, 0x24, 0x00, 0x00, 0x00, 0x03, 0x07, 0x00, 0x00,
-                0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
-                0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
-                0x36, 0x00, 0x00, 0x00, 0x01, 0x00, 0x61, 0x00, 0x01, 0x61, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                0x00, 0x00, 0x48, 0x00, 0x00, 0x00, 0x61, 0x00
-            });
-			IniMethods.WritePrivateProfileString("Archive", "SArchiveList", AI_BSA + ", " + GetBSAList(), strFalloutIniPath);
-		}
+            try
+            {
+
+                foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("Fallout - *.bsa"))
+                {
+                    fi.LastWriteTime = new DateTime(2008, 10, 1);
+                }
+
+                foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("Anchorage - *.bsa"))
+                {
+                    fi.LastWriteTime = new DateTime(2008, 10, 2);
+                }
+
+                foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("ThePitt - *.bsa"))
+                {
+                    fi.LastWriteTime = new DateTime(2008, 10, 3);
+                }
+
+                foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("BrokenSteel - *.bsa"))
+                {
+                    fi.LastWriteTime = new DateTime(2008, 10, 4);
+                }
+
+                foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("PointLookout - *.bsa"))
+                {
+                    fi.LastWriteTime = new DateTime(2008, 10, 5);
+                }
+
+                foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("Zeta - *.bsa"))
+                {
+                    fi.LastWriteTime = new DateTime(2008, 10, 6);
+                }
+
+                var falloutIniPath = GameMode.SettingsFiles.IniPath;
+
+                IniMethods.WritePrivateProfileInt32("Archive", "bInvalidateOlderFiles", 1, falloutIniPath);
+                IniMethods.WritePrivateProfileInt32("General", "bLoadFaceGenHeadEGTFiles", 1, falloutIniPath);
+                IniMethods.WritePrivateProfileString("Archive", "SInvalidationFile", "", falloutIniPath);
+                File.Delete(Path.Combine(pluginsPath, "archiveinvalidation.txt"));
+                File.WriteAllBytes(Path.Combine(pluginsPath, AI_BSA), new byte[]
+                {
+                    0x42, 0x53, 0x41, 0x00, 0x67, 0x00, 0x00, 0x00, 0x24, 0x00, 0x00, 0x00, 0x03, 0x07, 0x00, 0x00,
+                    0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+                    0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+                    0x36, 0x00, 0x00, 0x00, 0x01, 0x00, 0x61, 0x00, 0x01, 0x61, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x48, 0x00, 0x00, 0x00, 0x61, 0x00
+                });
+                IniMethods.WritePrivateProfileString("Archive", "SArchiveList", AI_BSA + ", " + GetBSAList(), falloutIniPath);
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceError("ApplyAI - Could not apply ArchiveInvalidation.");
+                TraceUtil.TraceException(ex);
+
+                MessageBox.Show(
+                    "Could not apply Archive Invalidation, at least one file could not be modified.\n" +
+                    "Please try again, or check trace log for more info.\n\n" +
+                    ex.Message,
+                    "Archive Invalidation failed",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+			}
+        }
 
 		/// <summary>
 		/// Disables AI.

--- a/Game Modes/Fallout4/Tools/AI/ArchiveInvalidation.cs
+++ b/Game Modes/Fallout4/Tools/AI/ArchiveInvalidation.cs
@@ -1,15 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using Nexus.Client.Games.Gamebryo.Tools.AI;
-using Nexus.Client.Util;
-using Nexus.Client.Games.Tools;
-using Nexus.Client.Commands;
-using Nexus.Client.Games.Gamebryo;
-
-namespace Nexus.Client.Games.Fallout4.Tools.AI
+﻿namespace Nexus.Client.Games.Fallout4.Tools.AI
 {
-	/// <summary>
+    using System;
+	using System.Diagnostics;
+	using System.IO;
+	using System.Windows.Forms;
+
+	using Nexus.Client.Util;
+    using Nexus.Client.Games.Tools;
+    using Nexus.Client.Commands;
+	
+    /// <summary>
 	/// Controls ArchiveInvalidation.
 	/// </summary>
 	public class ArchiveInvalidation : ITool
@@ -92,21 +92,58 @@ namespace Nexus.Client.Games.Fallout4.Tools.AI
         {
             if (ConfirmAiReset())
             {
-                string strPluginsPath = GameMode.PluginDirectory;
-                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("Fallout4 - *.ba2"))
-                    fi.LastWriteTime = new DateTime(2008, 10, 1);
-                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("DLCRobot - *.ba2"))
-                    fi.LastWriteTime = new DateTime(2008, 10, 2);
-                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("DLCworkshop01 - *.ba2"))
-                    fi.LastWriteTime = new DateTime(2008, 10, 3);
-                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("DLCCoast - *.ba2"))
-                    fi.LastWriteTime = new DateTime(2008, 10, 4);
-                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("DLCworkshop02 - *.ba2"))
-                    fi.LastWriteTime = new DateTime(2008, 10, 5);
-                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("DLCworkshop03 - *.ba2"))
-                    fi.LastWriteTime = new DateTime(2008, 10, 6);
-                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("DLCNukaWorld - *.ba2"))
-                    fi.LastWriteTime = new DateTime(2008, 10, 7);
+                var pluginsPath = GameMode.PluginDirectory;
+
+                try
+                {
+                    foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("Fallout4 - *.ba2"))
+                    {
+                        fi.LastWriteTime = new DateTime(2008, 10, 1);
+                    }
+
+                    foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("DLCRobot - *.ba2"))
+                    {
+                        fi.LastWriteTime = new DateTime(2008, 10, 2);
+                    }
+
+                    foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("DLCworkshop01 - *.ba2"))
+                    {
+                        fi.LastWriteTime = new DateTime(2008, 10, 3);
+                    }
+
+                    foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("DLCCoast - *.ba2"))
+                    {
+                        fi.LastWriteTime = new DateTime(2008, 10, 4);
+                    }
+
+                    foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("DLCworkshop02 - *.ba2"))
+                    {
+                        fi.LastWriteTime = new DateTime(2008, 10, 5);
+                    }
+
+                    foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("DLCworkshop03 - *.ba2"))
+                    {
+                        fi.LastWriteTime = new DateTime(2008, 10, 6);
+                    }
+
+                    foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("DLCNukaWorld - *.ba2"))
+                    {
+                        fi.LastWriteTime = new DateTime(2008, 10, 7);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Trace.TraceError("ApplyAI - Could not set LastWriteTime.");
+                    TraceUtil.TraceException(ex);
+
+                    MessageBox.Show(
+                        "Could not apply Archive Invalidation, at least one file could not be modified.\n" +
+                        "Please try again, or check trace log for more info.\n\n" +
+                        ex.Message,
+                        "Archive Invalidation failed",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
+				}
             }
         }
 	}

--- a/Game Modes/FalloutNV/Tools/AI/ArchiveInvalidation.cs
+++ b/Game Modes/FalloutNV/Tools/AI/ArchiveInvalidation.cs
@@ -1,12 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using Nexus.Client.Games.Gamebryo.Tools.AI;
-using Nexus.Client.Util;
-
-namespace Nexus.Client.Games.FalloutNV.Tools.AI
+﻿namespace Nexus.Client.Games.FalloutNV.Tools.AI
 {
-	/// <summary>
+    using System;
+    using System.Collections.Generic;
+	using System.Diagnostics;
+	using System.IO;
+	using System.Windows.Forms;
+
+	using Nexus.Client.Games.Gamebryo.Tools.AI;
+    using Nexus.Client.Util;
+	
+    /// <summary>
 	/// Controls ArchiveInvalidation.
 	/// </summary>
 	public class ArchiveInvalidation : ArchiveInvalidationBase
@@ -107,26 +110,49 @@ namespace Nexus.Client.Games.FalloutNV.Tools.AI
 		/// </summary>
 		protected override void ApplyAI()
 		{
-			string strPluginsPath = GameMode.PluginDirectory;
-			foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("Fallout - *.bsa"))
-				fi.LastWriteTime = new DateTime(2008, 10, 1);
-			foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("ClassicPack - *.bsa"))
-				fi.LastWriteTime = new DateTime(2008, 10, 1);
+			var pluginsPath = GameMode.PluginDirectory;
 
-			WriteIniInt("Archive", "bInvalidateOlderFiles", 1);
-			WriteIniInt("General", "bLoadFaceGenHeadEGTFiles", 1);
-			WriteIniString("Archive", "SInvalidationFile", "");
-			File.Delete(Path.Combine(strPluginsPath, "archiveinvalidation.txt"));
-			File.Delete(Path.Combine(strPluginsPath, OLD_AI_BSA));
-			File.WriteAllBytes(Path.Combine(strPluginsPath, AI_BSA), new byte[] {
-                0x42, 0x53, 0x41, 0x00, 0x67, 0x00, 0x00, 0x00, 0x24, 0x00, 0x00, 0x00, 0x03, 0x07, 0x00, 0x00,
-                0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
-                0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
-                0x36, 0x00, 0x00, 0x00, 0x01, 0x00, 0x61, 0x00, 0x01, 0x61, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                0x00, 0x00, 0x48, 0x00, 0x00, 0x00, 0x61, 0x00
-            });
-			WriteIniString("Archive", "SArchiveList", GetBSAList(true));
-		}
+            try
+            {
+                foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("Fallout - *.bsa"))
+                {
+                    fi.LastWriteTime = new DateTime(2008, 10, 1);
+                }
+
+                foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("ClassicPack - *.bsa"))
+                {
+                    fi.LastWriteTime = new DateTime(2008, 10, 1);
+                }
+
+                WriteIniInt("Archive", "bInvalidateOlderFiles", 1);
+                WriteIniInt("General", "bLoadFaceGenHeadEGTFiles", 1);
+                WriteIniString("Archive", "SInvalidationFile", "");
+                File.Delete(Path.Combine(pluginsPath, "archiveinvalidation.txt"));
+                File.Delete(Path.Combine(pluginsPath, OLD_AI_BSA));
+                File.WriteAllBytes(Path.Combine(pluginsPath, AI_BSA), new byte[]
+                {
+                    0x42, 0x53, 0x41, 0x00, 0x67, 0x00, 0x00, 0x00, 0x24, 0x00, 0x00, 0x00, 0x03, 0x07, 0x00, 0x00,
+                    0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+                    0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+                    0x36, 0x00, 0x00, 0x00, 0x01, 0x00, 0x61, 0x00, 0x01, 0x61, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x48, 0x00, 0x00, 0x00, 0x61, 0x00
+                });
+                WriteIniString("Archive", "SArchiveList", GetBSAList(true));
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceError("ApplyAI - Could not apply ArchiveInvalidation.");
+                TraceUtil.TraceException(ex);
+
+                MessageBox.Show(
+                    "Could not apply Archive Invalidation, at least one file could not be modified.\n" +
+                    "Please try again, or check trace log for more info.\n\n" +
+                    ex.Message,
+                    "Archive Invalidation failed",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+			}
+        }
 
 		/// <summary>
 		/// Disables AI.

--- a/Game Modes/Oblivion/Tools/AI/ArchiveInvalidation.cs
+++ b/Game Modes/Oblivion/Tools/AI/ArchiveInvalidation.cs
@@ -1,12 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using Nexus.Client.Games.Gamebryo.Tools.AI;
-using Nexus.Client.Util;
-
-namespace Nexus.Client.Games.Oblivion.Tools.AI
+﻿namespace Nexus.Client.Games.Oblivion.Tools.AI
 {
-	/// <summary>
+    using System;
+    using System.Collections.Generic;
+	using System.Diagnostics;
+	using System.IO;
+	using System.Windows.Forms;
+
+	using Nexus.Client.Games.Gamebryo.Tools.AI;
+    using Nexus.Client.Util;
+	
+    /// <summary>
 	/// Controls ArchiveInvalidation.
 	/// </summary>
 	public class ArchiveInvalidation : ArchiveInvalidationBase
@@ -73,25 +76,52 @@ namespace Nexus.Client.Games.Oblivion.Tools.AI
 		/// </summary>
 		protected override void ApplyAI()
 		{
-			string strPluginsPath = GameMode.PluginDirectory;
-			foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("Oblivion - *.bsa"))
-				fi.LastWriteTime = new DateTime(2005, 10, 1);
-			foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("DLC*.bsa"))
-				fi.LastWriteTime = new DateTime(2005, 10, 1);
-			foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("Knights.bsa"))
-				fi.LastWriteTime = new DateTime(2005, 10, 1);
+			var pluginsPath = GameMode.PluginDirectory;
 
-			string strIniPath = GameMode.SettingsFiles.IniPath;
-			IniMethods.WritePrivateProfileString("Archive", "SInvalidationFile", "", strIniPath);
-			FileUtil.ForceDelete(Path.Combine(strPluginsPath, "archiveinvalidation.txt"));
-			FileUtil.ForceDelete(Path.Combine(Path.Combine(GameMode.GameModeEnvironmentInfo.InstallationPath, "obmm"), AI_BSA));
-			File.WriteAllBytes(Path.Combine(strPluginsPath, AI_BSA), new byte[] {
-                0x42, 0x53, 0x41, 0x00, 0x67, 0x00, 0x00, 0x00, 0x24, 0x00, 0x00, 0x00, 0x03, 0x07, 0x00, 0x00,
-                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                0x02, 0x00, 0x00, 0x00
-            });
-			IniMethods.WritePrivateProfileString("Archive", "SArchiveList", GetBSAList(true), strIniPath);
-		}
+            try
+            {
+                foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("Oblivion - *.bsa"))
+                {
+                    fi.LastWriteTime = new DateTime(2005, 10, 1);
+                }
+
+                foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("DLC*.bsa"))
+                {
+                    fi.LastWriteTime = new DateTime(2005, 10, 1);
+                }
+
+                foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("Knights.bsa"))
+                {
+                    fi.LastWriteTime = new DateTime(2005, 10, 1);
+                }
+
+                var iniPath = GameMode.SettingsFiles.IniPath;
+                IniMethods.WritePrivateProfileString("Archive", "SInvalidationFile", "", iniPath);
+                FileUtil.ForceDelete(Path.Combine(pluginsPath, "archiveinvalidation.txt"));
+                FileUtil.ForceDelete(
+                    Path.Combine(Path.Combine(GameMode.GameModeEnvironmentInfo.InstallationPath, "obmm"), AI_BSA));
+                File.WriteAllBytes(Path.Combine(pluginsPath, AI_BSA), new byte[]
+                {
+                    0x42, 0x53, 0x41, 0x00, 0x67, 0x00, 0x00, 0x00, 0x24, 0x00, 0x00, 0x00, 0x03, 0x07, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x02, 0x00, 0x00, 0x00
+                });
+                IniMethods.WritePrivateProfileString("Archive", "SArchiveList", GetBSAList(true), iniPath);
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceError("ApplyAI - Could not apply ArchiveInvalidation.");
+                TraceUtil.TraceException(ex);
+
+                MessageBox.Show(
+                    "Could not apply Archive Invalidation, at least one file could not be modified.\n" +
+                    "Please try again, or check trace log for more info.\n\n" +
+                    ex.Message,
+                    "Archive Invalidation failed",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+			}
+        }
 
 		/// <summary>
 		/// Disables AI.

--- a/Game Modes/Skyrim/Tools/AI/ArchiveInvalidation.cs
+++ b/Game Modes/Skyrim/Tools/AI/ArchiveInvalidation.cs
@@ -1,15 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using Nexus.Client.Games.Gamebryo.Tools.AI;
-using Nexus.Client.Util;
-using Nexus.Client.Games.Tools;
-using Nexus.Client.Commands;
-using Nexus.Client.Games.Gamebryo;
-
-namespace Nexus.Client.Games.Skyrim.Tools.AI
+﻿namespace Nexus.Client.Games.Skyrim.Tools.AI
 {
-	/// <summary>
+    using System;
+	using System.Diagnostics;
+	using System.IO;
+	using System.Windows.Forms;
+
+	using Nexus.Client.Util;
+    using Nexus.Client.Games.Tools;
+    using Nexus.Client.Commands;
+	
+    /// <summary>
 	/// Controls ArchiveInvalidation.
 	/// </summary>
 	public class ArchiveInvalidation : ITool
@@ -92,19 +92,53 @@ namespace Nexus.Client.Games.Skyrim.Tools.AI
         {
             if (ConfirmAiReset())
             {
-                string strPluginsPath = GameMode.PluginDirectory;
-                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("Skyrim - *.bsa"))
-                    fi.LastWriteTime = new DateTime(2008, 10, 1);
-                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("Update.bsa"))
-                    fi.LastWriteTime = new DateTime(2008, 10, 2);
-                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("Dawnguard.bsa"))
-                    fi.LastWriteTime = new DateTime(2008, 10, 3);
-                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("HearthFires.bsa"))
-                    fi.LastWriteTime = new DateTime(2008, 10, 4);
-                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("Dragonborn.bsa"))
-                    fi.LastWriteTime = new DateTime(2008, 10, 5);
-                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("HighResTexturePack*.bsa"))
-                    fi.LastWriteTime = new DateTime(2008, 10, 6);
+                var pluginsPath = GameMode.PluginDirectory;
+
+                try
+                {
+                    foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("Skyrim - *.bsa"))
+                    {
+                        fi.LastWriteTime = new DateTime(2008, 10, 1);
+                    }
+
+                    foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("Update.bsa"))
+                    {
+                        fi.LastWriteTime = new DateTime(2008, 10, 2);
+                    }
+
+                    foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("Dawnguard.bsa"))
+                    {
+                        fi.LastWriteTime = new DateTime(2008, 10, 3);
+                    }
+
+                    foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("HearthFires.bsa"))
+                    {
+                        fi.LastWriteTime = new DateTime(2008, 10, 4);
+                    }
+
+                    foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("Dragonborn.bsa"))
+                    {
+                        fi.LastWriteTime = new DateTime(2008, 10, 5);
+                    }
+
+                    foreach (var fi in new DirectoryInfo(pluginsPath).GetFiles("HighResTexturePack*.bsa"))
+                    {
+                        fi.LastWriteTime = new DateTime(2008, 10, 6);
+                    }
+                }
+                catch (Exception ex)
+                {
+					Trace.TraceError("ApplyAI - Could not set LastWriteTime.");
+                    TraceUtil.TraceException(ex);
+
+                    MessageBox.Show(
+                        "Could not apply Archive Invalidation, at least one file could not be modified.\n" +
+                        "Please try again, or check trace log for more info.\n\n" + 
+                        ex.Message,
+                        "Archive Invalidation failed",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
+				}
             }
         }
 	}

--- a/Game Modes/SkyrimSE/Tools/AI/ArchiveInvalidation.cs
+++ b/Game Modes/SkyrimSE/Tools/AI/ArchiveInvalidation.cs
@@ -1,15 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using Nexus.Client.Games.Gamebryo.Tools.AI;
-using Nexus.Client.Util;
-using Nexus.Client.Games.Tools;
-using Nexus.Client.Commands;
-using Nexus.Client.Games.Gamebryo;
-
-namespace Nexus.Client.Games.SkyrimSE.Tools.AI
+﻿namespace Nexus.Client.Games.SkyrimSE.Tools.AI
 {
-	/// <summary>
+    using System;
+	using System.Diagnostics;
+	using System.IO;
+	using System.Windows.Forms;
+
+	using Nexus.Client.Util;
+    using Nexus.Client.Games.Tools;
+    using Nexus.Client.Commands;
+	
+    /// <summary>
 	/// Controls ArchiveInvalidation.
 	/// </summary>
 	public class ArchiveInvalidation : ITool
@@ -92,9 +92,28 @@ namespace Nexus.Client.Games.SkyrimSE.Tools.AI
         {
             if (ConfirmAiReset())
             {
-                string strPluginsPath = GameMode.PluginDirectory;
-                foreach (FileInfo fi in new DirectoryInfo(strPluginsPath).GetFiles("Skyrim - *.bsa"))
-                    fi.LastWriteTime = new DateTime(2008, 10, 1);
+                var pluginsPath = GameMode.PluginDirectory;
+                
+                foreach (var fileInfo in new DirectoryInfo(pluginsPath).GetFiles("Skyrim - *.bsa"))
+                {
+                    try
+                    {
+                        fileInfo.LastWriteTime = new DateTime(2008, 10, 1);
+                    }
+                    catch (Exception ex)
+                    {
+						Trace.TraceError($"ApplyAI - Could not set LastWriteTime of file \"{fileInfo.Name}\".");
+						TraceUtil.TraceException(ex);
+
+                        MessageBox.Show(
+                            "Could not apply Archive Invalidation, at least one file could not be modified.\n" +
+                            "Please try again, or check trace log for more info.\n\n" +
+                            ex.Message,
+                            "Archive Invalidation failed",
+                            MessageBoxButtons.OK,
+                            MessageBoxIcon.Error);
+					}
+                }
             }
         }
 	}


### PR DESCRIPTION
Pretty much just added try/catch clauses, that log issues and shows an error message to the user.

Prompted by #968 