### PR TITLE
Fix NullReferenceException in AddModTask.BuildDescriptor

### DIFF
--- a/NexusClient/ModManagement/AddModTask.cs
+++ b/NexusClient/ModManagement/AddModTask.cs
@@ -635,6 +635,12 @@
 
                         var downloadLinks = _modRepository.GetFilePartInfo(nxuModUrl.ModId, fileInfo.Id, nxuModUrl.Key, nxuModUrl.Expiry);
 
+						if (downloadLinks == null)
+						{
+							Trace.TraceError($"Could not retrieve download links for mod \"{nxuModUrl.ModId}\", file \"{fileInfo.Id}\".");
+							return null;
+						}
+
                         if (downloadLinks.Count > 0)
                         {
                             foreach (var link in downloadLinks)


### PR DESCRIPTION
Seen several issues from this, unsure of the root cause, but at the very least we should not crash.

#999 , #984, etc.

Some of the issues look like there's a problem with the NXM URL: `Pathoschild.Http.Client.ApiException: Provided key and expire time isn't correct for this user/file.` - not sure if this could happen if you're logged in with one account on the website and another one in NMM - or if there's some other issue?